### PR TITLE
Fix highlighting for substitutions using braces as delimiters.

### DIFF
--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -167,7 +167,7 @@
     'applyEndPatternLast': 1
     'begin': '\\b(?=(?<!\\&)(s)(\\s+\\S|\\s*[;\\,\\#\\{\\}\\(\\)\\[<]|$))'
     'comment': 'string.regexp.replace.perl'
-    'end': '((([egimosxradlu]*)))(?=(\\s+\\S|\\s*[;\\,\\#\\{\\}\\)\\]>]|$))'
+    'end': '((([egimosxradlu]*)))(?=(\\s+\\S|\\s*[;\\,\\#\\}\\)\\]>]|$))'
     'endCaptures':
       '1':
         'name': 'string.regexp.replace.perl'


### PR DESCRIPTION
The end regex was matching on the open brace in the lookahead.
