### PR TITLE
Added missing RegEx modifiers

### DIFF
--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -361,9 +361,9 @@
     ]
   }
   {
-    'begin': '\\b(?=s([^\\s\\w\\[({<]).*\\1([egimosxradlu]*)([\\}\\)\\;\\,]|\\s+))'
+    'begin': '\\b(?=s([^\\s\\w\\[({<]).*\\1([egimosxradlupc]*)([\\}\\)\\;\\,]|\\s+))'
     'comment': 'string.regexp.replaceXXX'
-    'end': '((([egimosxradlu]*)))(?=([\\}\\)\\;\\,]|\\s+|$))'
+    'end': '((([egimosxradlupc]*)))(?=([\\}\\)\\;\\,]|\\s+|$))'
     'endCaptures':
       '1':
         'name': 'string.regexp.replace.perl'


### PR DESCRIPTION
Added /p preserve the string matched such that ${^PREMATCH}, ${^MATCH}, and ${^POSTMATCH} are available for use after matching.
Added /c keep the current position during repeated matching

As listed here http://perldoc.perl.org/perlre.html