### PR TITLE
Added missing perl5 functions

### DIFF
--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -538,7 +538,7 @@
         'name': 'entity.name.function.perl'
       '3':
         'name': 'storage.type.method.perl'
-    'match': '^\\s*(sub)\\s+([-a-zA-Z0-9_]+)\\s*(\\([\\$\\@\\*;]*\\))?'
+    'match': '\\b(sub)(?:\\s+([-a-zA-Z0-9_]+))?\\s*(?:\\([\\$\\@\\*;]*\\))?[^\\w\\{]'
     'name': 'meta.function.perl'
   }
   {
@@ -696,7 +696,7 @@
     'name': 'keyword.operator.filetest.perl'
   }
   {
-    'match': '\\b(and|or|xor|as)\\b'
+    'match': '\\b(and|or|xor|as|not)\\b'
     'name': 'keyword.operator.logical.perl'
   }
   {
@@ -1514,7 +1514,15 @@
     ]
   }
   {
-    'match': '\\b(ARGV|DATA|ENV|SIG|STDERR|STDIN|STDOUT|atan2|bind|binmode|bless|caller|chdir|chmod|chomp|chop|chown|chr|chroot|close|closedir|cmp|connect|cos|crypt|dbmclose|dbmopen|defined|delete|dump|each|endgrent|endhostent|endnetent|endprotoent|endpwent|endservent|eof|eq|eval|exec|exists|exp|fcntl|fileno|flock|fork|format|formline|ge|getc|getgrent|getgrgid|getgrnam|gethostbyaddr|gethostbyname|gethostent|getlogin|getnetbyaddr|getnetbyname|getnetent|getpeername|getpgrp|getppid|getpriority|getprotobyname|getprotobynumber|getprotoent|getpwent|getpwnam|getpwuid|getservbyname|getservbyport|getservent|getsockname|getsockopt|glob|gmtime|grep|gt|hex|import|index|int|ioctl|join|keys|kill|lc|lcfirst|le|length|link|listen|local|localtime|log|lstat|lt|m|map|mkdir|msgctl|msgget|msgrcv|msgsnd|ne|no|oct|open|opendir|ord|pack|pipe|pop|pos|print|printf|push|q|qq|quotemeta|qw|qx|rand|read|readdir|readlink|recv|ref|rename|reset|reverse|rewinddir|rindex|rmdir|s|scalar|seek|seekdir|semctl|semget|semop|send|setgrent|sethostent|setnetent|setpgrp|setpriority|setprotoent|setpwent|setservent|setsockopt|shift|shmctl|shmget|shmread|shmwrite|shutdown|sin|sleep|socket|socketpair|sort|splice|split|sprintf|sqrt|srand|stat|study|substr|symlink|syscall|sysopen|sysread|system|syswrite|tell|telldir|tie|tied|time|times|tr|truncate|uc|ucfirst|umask|undef|unlink|unpack|unshift|untie|utime|values|vec|waitpid|wantarray|warn|write|y|q|qw|qq|qx)\\b'
+    'match': '\\b(x)\\s*(\\d+)\\b'
+    'captures':
+      '0':
+        'name': 'support.function.perl'
+      '1':
+        'name': 'entity.name.function.perl'
+  }
+  {
+    'match': '\\b(ARGV|DATA|ENV|SIG|STDERR|STDIN|STDOUT|accept|alarm|atan2|bind|binmode|bless|caller|chdir|chmod|chomp|chop|chown|chr|chroot|close|closedir|cmp|connect|cos|crypt|dbmclose|dbmopen|defined|delete|dump|each|endgrent|endhostent|endnetent|endprotoent|endpwent|endservent|eof|eq|eval|exec|exists|exp|fc|fcntl|fileno|flock|fork|format|formline|ge|getc|getgrent|getgrgid|getgrnam|gethostbyaddr|gethostbyname|gethostent|getlogin|getnetbyaddr|getnetbyname|getnetent|getpeername|getpgrp|getppid|getpriority|getprotobyname|getprotobynumber|getprotoent|getpwent|getpwnam|getpwuid|getservbyname|getservbyport|getservent|getsockname|getsockopt|glob|gmtime|grep|gt|hex|import|index|int|ioctl|join|keys|kill|lc|lcfirst|le|length|link|listen|local|localtime|lock|log|lstat|lt|m|map|mkdir|msgctl|msgget|msgrcv|msgsnd|ne|no|oct|open|opendir|ord|pack|pipe|pop|pos|print|printf|prototype|push|q|qq|quotemeta|qw|qx|rand|read|readdir|readline|readlink|readpipe|recv|ref|rename|reset|reverse|rewinddir|rindex|rmdir|s|scalar|seek|seekdir|semctl|semget|semop|send|setgrent|sethostent|setnetent|setpgrp|setpriority|setprotoent|setpwent|setservent|setsockopt|shift|shmctl|shmget|shmread|shmwrite|shutdown|sin|sleep|socket|socketpair|sort|splice|split|sprintf|sqrt|srand|stat|study|substr|symlink|syscall|sysopen|sysread|sysseek|system|syswrite|tell|telldir|tie|tied|time|times|tr|truncate|uc|ucfirst|umask|undef|unlink|unpack|unshift|untie|utime|values|vec|waitpid|wantarray|warn|write|y|q|qw|qq|qx)\\b'
     'name': 'support.function.perl'
   }
 ]

--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -1516,9 +1516,9 @@
   {
     'match': '\\b(x)\\s*(\\d+)\\b'
     'captures':
-      '0':
-        'name': 'support.function.perl'
       '1':
+        'name': 'support.function.perl'
+      '2':
         'name': 'entity.name.function.perl'
   }
   {


### PR DESCRIPTION
I added all missing perl5 functions and operators which are listed here http://perldoc.perl.org/index-functions.html

+ Added function
accept,alarm,fc,lock,prototype,readline,readpipe,sysseek,x
+ Added operator not
+ Added support for anonymous subroutines

Old ([sub](http://perldoc.perl.org/perlsub.html) changes):
![old_sub](https://cloud.githubusercontent.com/assets/1900106/6583092/2593740e-c762-11e4-9f05-7196c2234bfc.png)

New ([sub](http://perldoc.perl.org/perlsub.html) changes):
![new_sub](https://cloud.githubusercontent.com/assets/1900106/6583093/27751bec-c762-11e4-989d-c9ed0e41691d.png)

New [x](http://perldoc.perl.org/functions/x.html):
![x](https://cloud.githubusercontent.com/assets/1900106/6583352/ee90d40e-c763-11e4-8379-cadeded76b04.png)

@kevinsawicki could you please show an example how to test a multiline highlighting like:
```perl
my $asd = sub {
    print "asd";
};
```
