### PR TITLE
Added large escape sequence highlight support

### DIFF
--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -1528,8 +1528,44 @@
 ]
 'repository':
   'escaped_char':
-    'match': '\\\\.'
-    'name': 'constant.character.escape.perl'
+    'patterns': [
+      {
+        'match': '\\\\\\d+'
+        'name': 'constant.character.escape.perl'
+      }
+      {
+        'match': '\\\\c[^\\s\\\\]'
+        'name': 'constant.character.escape.perl'
+      }
+      {
+        'match': '\\\\g(?:\\{(?:\\w*|-\\d+)\\}|\\d+)'
+        'name': 'constant.character.escape.perl'
+      }
+      {
+        'match': '\\\\k(?:\\{\\w*\\}|<\\w*>|\'\\w*\')'
+        'name': 'constant.character.escape.perl'
+      }
+      {
+        'match': '\\\\N\\{[^\\}]*\\}'
+        'name': 'constant.character.escape.perl'
+      }
+      {
+        'match': '\\\\o\\{\\d*\\}'
+        'name': 'constant.character.escape.perl'
+      }
+      {
+        'match': '\\\\(?:p|P)(?:\\{\\w*\\}|P)'
+        'name': 'constant.character.escape.perl'
+      }
+      {
+        'match': '\\\\x(?:\\w+|\\{\\w*\\})?'
+        'name': 'constant.character.escape.perl'
+      }
+      {
+        'match': '\\\\.'
+        'name': 'constant.character.escape.perl'
+      }
+    ]
   'line_comment':
     'patterns': [
       {


### PR DESCRIPTION
Now the complete escape sequence will be highlighted instead of only the keyword, this increases the readability of long string which contains escape sequences.
This resolves #23 
![large_escape1](https://cloud.githubusercontent.com/assets/1900106/6665917/6a7113d4-cbdf-11e4-91a7-6be4c093650e.png)
![large_escape2](https://cloud.githubusercontent.com/assets/1900106/6665918/6cd0d894-cbdf-11e4-925b-d5356ad0f8b8.png)
