### PR TITLE
Removed duplicate regex replace entry

### DIFF
--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -676,7 +676,7 @@
         'name': 'punctuation.definition.string.perl'
       '8':
         'name': 'punctuation.definition.string.perl'
-    'match': '\\b(s|tr|y)\\s*([^A-Za-z0-9\\s])(.*?)(?<!\\\\)(\\\\{2})*(\\2)(.*?)(?<!\\\\)(\\\\{2})*(\\2)'
+    'match': '\\b(tr|y)\\s*([^A-Za-z0-9\\s])(.*?)(?<!\\\\)(\\\\{2})*(\\2)(.*?)(?<!\\\\)(\\\\{2})*(\\2)'
     'name': 'string.regexp.replace.perl'
   }
   {


### PR DESCRIPTION
This causes weired highlight issues #6 . The regex replace is handled in other grammar patterns too, i think this was the first regex replace pattern and later they increased it, so this is an oboslete pattern. But first i only removed the regex replace pattern.