### PR TITLE
Regex rewrite

### DIFF
--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -166,7 +166,7 @@
   }
   {
     'applyEndPatternLast': 1
-    'begin': '\\b(?=m\\s*[^\\s\\w])'
+    'begin': '\\b(?=m\\s*[^\\sa-zA-Z0-9])'
     'comment': 'string.regexp.find-m.perl'
     'end': '((([egimosxradlupc]*)))(?=(\\s+\\S|\\s*[;\\,\\#\\{\\}\\)]|$))'
     'endCaptures':
@@ -277,7 +277,7 @@
         ]
       }
       {
-        'begin': '(m)\\s*([^\\s\\w\\\'\\{\\[\\(\\<])'
+        'begin': '(m)\\s*([^\\sa-zA-Z0-9\\\'\\{\\[\\(\\<])'
         'captures':
           '0':
             'name': 'punctuation.definition.string.perl'
@@ -288,7 +288,7 @@
         'patterns': [
           {
             'comment': 'This is to prevent thinks like qr/foo$/ to treat $/ as a variable'
-            'match': '\\$(?=[^\\s\\w\\\'\\{\\[\\(\\<])'
+            'match': '\\$(?=[^\\sa-zA-Z0-9\\\'\\{\\[\\(\\<])'
             'name': 'keyword.control.anchor.perl'
           }
           {
@@ -618,19 +618,11 @@
     ]
   }
   {
-    'match': '\\b\\w+\\s*(?==>)'
-    'name': 'constant.other.key.perl'
-  }
-  {
-    'match': '(?<={)\\s*\\w+\\s*(?=})'
-    'name': 'constant.other.bareword.perl'
-  }
-  {
-    'begin': '(?<!\\\\)((~\\s*)?\\/)(?=\\S)(?=([^\\\\]|\\\\.)*\\/)'
-    'captures':
+    'begin': '(?<=\\(|\\{|~|&)\\s*(\\/)'
+    'beginCaptures':
       '1':
         'name': 'punctuation.definition.string.perl'
-    'end': '(\\/([egimosxradlupc]*))'
+    'end': '(\\1([egimosxradlupc]*))(?=(\\s+\\S|\\s*[;\\,\\#\\{\\}\\)]|$))'
     'endCaptures':
       '1':
         'name': 'punctuation.definition.string.perl'
@@ -639,21 +631,10 @@
     'name': 'string.regexp.find.perl'
     'patterns': [
       {
-        'include': '#escaped_char'
+        'comment': 'This is to prevent thinks like /foo$/ to treat $/ as a variable'
+        'match': '\\$(?=\\/)'
+        'name': 'keyword.control.anchor.perl'
       }
-    ]
-  }
-  {
-    'begin': '(?<!\\\\)(\\~\\s*\\/)'
-    'captures':
-      '0':
-        'name': 'punctuation.definition.string.perl'
-    'end': '\\/([cgimos]*x[cgimos]*)\\b'
-    'endCaptures':
-      '1':
-        'name': 'keyword.control.regexp-option.perl'
-    'name': 'string.regexp.find.extended.perl'
-    'patterns': [
       {
         'include': '#escaped_char'
       }
@@ -661,6 +642,14 @@
         'include': '#variable'
       }
     ]
+  }
+  {
+    'match': '\\b\\w+\\s*(?==>)'
+    'name': 'constant.other.key.perl'
+  }
+  {
+    'match': '(?<={)\\s*\\w+\\s*(?=})'
+    'name': 'constant.other.bareword.perl'
   }
   {
     'captures':

--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -618,17 +618,21 @@
     ]
   }
   {
-    'begin': '(?<=\\(|\\{|~|&)\\s*(\\/)'
+    'begin': '(?<=\\(|\\{|~|&)\\s*((\\/))'
     'beginCaptures':
       '1':
+        'name': 'string.regexp.find.perl'
+      '2':
         'name': 'punctuation.definition.string.perl'
-    'end': '(\\1([egimosxradlupc]*))(?=(\\s+\\S|\\s*[;\\,\\#\\{\\}\\)]|$))'
+    'end': '((\\1([egimosxradlupc]*)))(?=(\\s+\\S|\\s*[;\\,\\#\\{\\}\\)]|$))'
     'endCaptures':
       '1':
-        'name': 'punctuation.definition.string.perl'
+        'name': 'string.regexp.find.perl'
       '2':
+        'name': 'punctuation.definition.string.perl'
+      '3':
         'name': 'keyword.control.regexp-option.perl'
-    'name': 'string.regexp.find.perl'
+    'contentName': 'string.regexp.find.perl'
     'patterns': [
       {
         'comment': 'This is to prevent thinks like /foo$/ to treat $/ as a variable'

--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -630,13 +630,11 @@
     'captures':
       '1':
         'name': 'punctuation.definition.string.perl'
-    'end': '(?:\\/((([egimosxradlupc]*))))'
+    'end': '(\\/([egimosxradlupc]*))'
     'endCaptures':
       '1':
-        'name': 'string.regexp.find.perl'
-      '2':
         'name': 'punctuation.definition.string.perl'
-      '3':
+      '2':
         'name': 'keyword.control.regexp-option.perl'
     'name': 'string.regexp.find.perl'
     'patterns': [

--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -166,6 +166,146 @@
   }
   {
     'applyEndPatternLast': 1
+    'begin': '\\b(?=m\\s*[^\\s\\w])'
+    'comment': 'string.regexp.find-m.perl'
+    'end': '((([egimosxradlupc]*)))(?=(\\s+\\S|\\s*[;\\,\\#\\{\\}\\)]|$))'
+    'endCaptures':
+      '1':
+        'name': 'string.regexp.find-m.perl'
+      '2':
+        'name': 'punctuation.definition.string.perl'
+      '3':
+        'name': 'keyword.control.regexp-option.perl'
+    'patterns': [
+      {
+        'begin': '(m)\\s*\\{'
+        'captures':
+          '0':
+            'name': 'punctuation.definition.string.perl'
+          '1':
+            'name': 'support.function.perl'
+        'end': '\\}'
+        'name': 'string.regexp.find-m.nested_braces.perl'
+        'patterns': [
+          {
+            'include': '#escaped_char'
+          }
+          {
+            'include': '#variable'
+          }
+          {
+            'include': '#nested_braces_interpolated'
+          }
+        ]
+      }
+      {
+        'begin': '(m)\\s*\\['
+        'captures':
+          '0':
+            'name': 'punctuation.definition.string.perl'
+          '1':
+            'name': 'support.function.perl'
+        'end': '\\]'
+        'name': 'string.regexp.find-m.nested_brackets.perl'
+        'patterns': [
+          {
+            'include': '#escaped_char'
+          }
+          {
+            'include': '#variable'
+          }
+          {
+            'include': '#nested_brackets_interpolated'
+          }
+        ]
+      }
+      {
+        'begin': '(m)\\s*<'
+        'captures':
+          '0':
+            'name': 'punctuation.definition.string.perl'
+          '1':
+            'name': 'support.function.perl'
+        'end': '>'
+        'name': 'string.regexp.find-m.nested_ltgt.perl'
+        'patterns': [
+          {
+            'include': '#escaped_char'
+          }
+          {
+            'include': '#variable'
+          }
+          {
+            'include': '#nested_ltgt_interpolated'
+          }
+        ]
+      }
+      {
+        'begin': '(m)\\s*\\('
+        'captures':
+          '0':
+            'name': 'punctuation.definition.string.perl'
+          '1':
+            'name': 'support.function.perl'
+        'end': '\\)'
+        'name': 'string.regexp.find-m.nested_parens.perl'
+        'patterns': [
+          {
+            'include': '#escaped_char'
+          }
+          {
+            'include': '#variable'
+          }
+          {
+            'include': '#nested_parens_interpolated'
+          }
+        ]
+      }
+      {
+        'begin': '(m)\\s*\\\''
+        'captures':
+          '0':
+            'name': 'punctuation.definition.string.perl'
+          '1':
+            'name': 'support.function.perl'
+        'end': '\\\''
+        'name': 'string.regexp.find-m.single-quote.perl'
+        'patterns': [
+          {
+            'include': '#escaped_char'
+          }
+        ]
+      }
+      {
+        'begin': '(m)\\s*([^\\s\\w\\\'\\{\\[\\(\\<])'
+        'captures':
+          '0':
+            'name': 'punctuation.definition.string.perl'
+          '1':
+            'name': 'support.function.perl'
+        'end': '\\2'
+        'name': 'string.regexp.find-m.simple-delimiter.perl'
+        'patterns': [
+          {
+            'comment': 'This is to prevent thinks like qr/foo$/ to treat $/ as a variable'
+            'match': '\\$(?=[^\\s\\w\\\'\\{\\[\\(\\<])'
+            'name': 'keyword.control.anchor.perl'
+          }
+          {
+            'include': '#escaped_char'
+          }
+          {
+            'include': '#variable'
+          }
+          {
+            'include': '#nested_parens_interpolated'
+          }
+        ]
+      }
+    ]
+  }
+  {
+    'applyEndPatternLast': 1
     'begin': '\\b(?=(?<!\\&)(s)(\\s+\\S|\\s*[;\\,\\#\\{\\}\\(\\)\\[<]|$))'
     'comment': 'string.regexp.replace.perl'
     'end': '((([egimosxradlupc]*)))(?=(\\s+\\S|\\s*[;\\,\\#\\}\\)\\]>]|$))'
@@ -490,7 +630,14 @@
     'captures':
       '1':
         'name': 'punctuation.definition.string.perl'
-    'end': '(\\/)'
+    'end': '(?:\\/((([egimosxradlupc]*))))'
+    'endCaptures':
+      '1':
+        'name': 'string.regexp.find.perl'
+      '2':
+        'name': 'punctuation.definition.string.perl'
+      '3':
+        'name': 'keyword.control.regexp-option.perl'
     'name': 'string.regexp.find.perl'
     'patterns': [
       {
@@ -564,105 +711,6 @@
           '2':
             'name': 'meta.even-tab'
         'match': '(\\t| {4})(\\t| {4})?'
-      }
-    ]
-  }
-  {
-    'captures':
-      '1':
-        'name': 'support.function.perl'
-      '2':
-        'name': 'punctuation.definition.string.perl'
-      '5':
-        'name': 'punctuation.definition.string.perl'
-    'match': '\\b(m)\\s*(?<!\\\\)([^\\[\\{\\(A-Za-z0-9\\s])(.*?)(?<!\\\\)(\\\\{2})*(\\2)'
-    'name': 'string.regexp.find-m.perl'
-  }
-  {
-    'begin': '\\b(m)\\s*(?<!\\\\)\\('
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.perl'
-    'end': '\\)'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.perl'
-    'name': 'string.regexp.find-m-paren.perl'
-    'patterns': [
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#nested_parens_interpolated'
-      }
-      {
-        'include': '#variable'
-      }
-    ]
-  }
-  {
-    'begin': '\\b(m)\\s*(?<!\\\\)\\{'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.perl'
-    'end': '\\}'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.perl'
-    'name': 'string.regexp.find-m-brace.perl'
-    'patterns': [
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#nested_braces_interpolated'
-      }
-      {
-        'include': '#variable'
-      }
-    ]
-  }
-  {
-    'begin': '\\b(m)\\s*(?<!\\\\)\\['
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.perl'
-    'end': '\\]'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.perl'
-    'name': 'string.regexp.find-m-bracket.perl'
-    'patterns': [
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#nested_brackets_interpolated'
-      }
-      {
-        'include': '#variable'
-      }
-    ]
-  }
-  {
-    'begin': '\\b(m)\\s*(?<!\\\\)\\<'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.perl'
-    'end': '\\>'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.perl'
-    'name': 'string.regexp.find-m-ltgt.perl'
-    'patterns': [
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#nested_ltgt_interpolated'
-      }
-      {
-        'include': '#variable'
       }
     ]
   }

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -14,109 +14,109 @@ describe "perl grammar", ->
 
   describe "when a regexp compile tokenizes", ->
     it "works with all bracket/seperator variations", ->
-      {tokens} = grammar.tokenizeLine("qr/text/egimosxradlupc;")
+      {tokens} = grammar.tokenizeLine("qr/text/acdegilmoprsux;")
       expect(tokens[0]).toEqual value: "qr", scopes: ["source.perl", "string.regexp.compile.simple-delimiter.perl", "punctuation.definition.string.perl", "support.function.perl"]
       expect(tokens[1]).toEqual value: "/", scopes: ["source.perl", "string.regexp.compile.simple-delimiter.perl", "punctuation.definition.string.perl"]
       expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.compile.simple-delimiter.perl"]
       expect(tokens[3]).toEqual value: "/", scopes: ["source.perl", "string.regexp.compile.simple-delimiter.perl", "punctuation.definition.string.perl"]
-      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.compile.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[4]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.compile.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
       expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
 
-      {tokens} = grammar.tokenizeLine("qr(text)egimosxradlupc;")
+      {tokens} = grammar.tokenizeLine("qr(text)acdegilmoprsux;")
       expect(tokens[0]).toEqual value: "qr", scopes: ["source.perl", "string.regexp.compile.nested_parens.perl", "punctuation.definition.string.perl", "support.function.perl"]
       expect(tokens[1]).toEqual value: "(", scopes: ["source.perl", "string.regexp.compile.nested_parens.perl", "punctuation.definition.string.perl"]
       expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.compile.nested_parens.perl"]
       expect(tokens[3]).toEqual value: ")", scopes: ["source.perl", "string.regexp.compile.nested_parens.perl", "punctuation.definition.string.perl"]
-      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.compile.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[4]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.compile.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
       expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
 
-      {tokens} = grammar.tokenizeLine("qr{text}egimosxradlupc;")
+      {tokens} = grammar.tokenizeLine("qr{text}acdegilmoprsux;")
       expect(tokens[0]).toEqual value: "qr", scopes: ["source.perl", "string.regexp.compile.nested_braces.perl", "punctuation.definition.string.perl", "support.function.perl"]
       expect(tokens[1]).toEqual value: "{", scopes: ["source.perl", "string.regexp.compile.nested_braces.perl", "punctuation.definition.string.perl"]
       expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.compile.nested_braces.perl"]
       expect(tokens[3]).toEqual value: "}", scopes: ["source.perl", "string.regexp.compile.nested_braces.perl", "punctuation.definition.string.perl"]
-      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.compile.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[4]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.compile.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
       expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
 
-      {tokens} = grammar.tokenizeLine("qr[text]egimosxradlupc;")
+      {tokens} = grammar.tokenizeLine("qr[text]acdegilmoprsux;")
       expect(tokens[0]).toEqual value: "qr", scopes: ["source.perl", "string.regexp.compile.nested_brackets.perl", "punctuation.definition.string.perl", "support.function.perl"]
       expect(tokens[1]).toEqual value: "[", scopes: ["source.perl", "string.regexp.compile.nested_brackets.perl", "punctuation.definition.string.perl"]
       expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.compile.nested_brackets.perl"]
       expect(tokens[3]).toEqual value: "]", scopes: ["source.perl", "string.regexp.compile.nested_brackets.perl", "punctuation.definition.string.perl"]
-      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.compile.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[4]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.compile.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
       expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
 
-      {tokens} = grammar.tokenizeLine("qr<text>egimosxradlupc;")
+      {tokens} = grammar.tokenizeLine("qr<text>acdegilmoprsux;")
       expect(tokens[0]).toEqual value: "qr", scopes: ["source.perl", "string.regexp.compile.nested_ltgt.perl", "punctuation.definition.string.perl", "support.function.perl"]
       expect(tokens[1]).toEqual value: "<", scopes: ["source.perl", "string.regexp.compile.nested_ltgt.perl", "punctuation.definition.string.perl"]
       expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.compile.nested_ltgt.perl"]
       expect(tokens[3]).toEqual value: ">", scopes: ["source.perl", "string.regexp.compile.nested_ltgt.perl", "punctuation.definition.string.perl"]
-      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.compile.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[4]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.compile.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
       expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
 
 
   describe "when a regexp find tokenizes", ->
     it "works with all bracket/seperator variations", ->
-      {tokens} = grammar.tokenizeLine("/text/egimosxradlupc;")
+      {tokens} = grammar.tokenizeLine("/text/acdegilmoprsux;")
       expect(tokens[0]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
       expect(tokens[1]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find.perl"]
       expect(tokens[2]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
-      expect(tokens[3]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[3]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
       expect(tokens[4]).toEqual value: ";", scopes: ["source.perl"]
 
-      {tokens} = grammar.tokenizeLine("m/text/egimosxradlupc;")
+      {tokens} = grammar.tokenizeLine("m/text/acdegilmoprsux;")
       expect(tokens[0]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl", "punctuation.definition.string.perl", "support.function.perl"]
       expect(tokens[1]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl", "punctuation.definition.string.perl"]
       expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl"]
       expect(tokens[3]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl", "punctuation.definition.string.perl"]
-      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[4]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
       expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
 
-      {tokens} = grammar.tokenizeLine("m(text)egimosxradlupc;")
+      {tokens} = grammar.tokenizeLine("m(text)acdegilmoprsux;")
       expect(tokens[0]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.nested_parens.perl", "punctuation.definition.string.perl", "support.function.perl"]
       expect(tokens[1]).toEqual value: "(", scopes: ["source.perl", "string.regexp.find-m.nested_parens.perl", "punctuation.definition.string.perl"]
       expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.nested_parens.perl"]
       expect(tokens[3]).toEqual value: ")", scopes: ["source.perl", "string.regexp.find-m.nested_parens.perl", "punctuation.definition.string.perl"]
-      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[4]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
       expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
 
-      {tokens} = grammar.tokenizeLine("m{text}egimosxradlupc;")
+      {tokens} = grammar.tokenizeLine("m{text}acdegilmoprsux;")
       expect(tokens[0]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.nested_braces.perl", "punctuation.definition.string.perl", "support.function.perl"]
       expect(tokens[1]).toEqual value: "{", scopes: ["source.perl", "string.regexp.find-m.nested_braces.perl", "punctuation.definition.string.perl"]
       expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.nested_braces.perl"]
       expect(tokens[3]).toEqual value: "}", scopes: ["source.perl", "string.regexp.find-m.nested_braces.perl", "punctuation.definition.string.perl"]
-      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[4]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
       expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
 
-      {tokens} = grammar.tokenizeLine("m[text]egimosxradlupc;")
+      {tokens} = grammar.tokenizeLine("m[text]acdegilmoprsux;")
       expect(tokens[0]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.nested_brackets.perl", "punctuation.definition.string.perl", "support.function.perl"]
       expect(tokens[1]).toEqual value: "[", scopes: ["source.perl", "string.regexp.find-m.nested_brackets.perl", "punctuation.definition.string.perl"]
       expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.nested_brackets.perl"]
       expect(tokens[3]).toEqual value: "]", scopes: ["source.perl", "string.regexp.find-m.nested_brackets.perl", "punctuation.definition.string.perl"]
-      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[4]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
       expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
 
-      {tokens} = grammar.tokenizeLine("m<text>egimosxradlupc;")
+      {tokens} = grammar.tokenizeLine("m<text>acdegilmoprsux;")
       expect(tokens[0]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.nested_ltgt.perl", "punctuation.definition.string.perl", "support.function.perl"]
       expect(tokens[1]).toEqual value: "<", scopes: ["source.perl", "string.regexp.find-m.nested_ltgt.perl", "punctuation.definition.string.perl"]
       expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.nested_ltgt.perl"]
       expect(tokens[3]).toEqual value: ">", scopes: ["source.perl", "string.regexp.find-m.nested_ltgt.perl", "punctuation.definition.string.perl"]
-      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[4]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
       expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
 
 
   describe "when a regexp replace tokenizes", ->
     it "works with all bracket/seperator variations", ->
-      {tokens} = grammar.tokenizeLine("s/text/test/egimosxradlupc")
+      {tokens} = grammar.tokenizeLine("s/text/test/acdegilmoprsux")
       expect(tokens[0]).toEqual value: "s", scopes: ["source.perl", "string.regexp.replaceXXX.simple_delimiter.perl", "punctuation.definition.string.perl", "support.function.perl"]
       expect(tokens[1]).toEqual value: "/", scopes: ["source.perl", "string.regexp.replaceXXX.simple_delimiter.perl", "punctuation.definition.string.perl"]
       expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.replaceXXX.simple_delimiter.perl"]
       expect(tokens[3]).toEqual value: "/", scopes: ["source.perl", "string.regexp.replaceXXX.format.simple_delimiter.perl", "punctuation.definition.string.perl"]
       expect(tokens[4]).toEqual value: "test", scopes: ["source.perl", "string.regexp.replaceXXX.format.simple_delimiter.perl"]
       expect(tokens[5]).toEqual value: "/", scopes: ["source.perl", "string.regexp.replaceXXX.format.simple_delimiter.perl", "punctuation.definition.string.perl"]
-      expect(tokens[6]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[6]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
 
-      {tokens} = grammar.tokenizeLine("s(text)(test)egimosxradlupc")
+      {tokens} = grammar.tokenizeLine("s(text)(test)acdegilmoprsux")
       expect(tokens[0]).toEqual value: "s", scopes: ["source.perl", "string.regexp.nested_parens.perl", "punctuation.definition.string.perl", "support.function.perl"]
       expect(tokens[1]).toEqual value: "(", scopes: ["source.perl", "string.regexp.nested_parens.perl", "punctuation.definition.string.perl"]
       expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.nested_parens.perl"]
@@ -124,9 +124,9 @@ describe "perl grammar", ->
       expect(tokens[4]).toEqual value: "(", scopes: ["source.perl", "string.regexp.format.nested_parens.perl", "punctuation.definition.string.perl"]
       expect(tokens[5]).toEqual value: "test", scopes: ["source.perl", "string.regexp.format.nested_parens.perl"]
       expect(tokens[6]).toEqual value: ")", scopes: ["source.perl", "string.regexp.format.nested_parens.perl", "punctuation.definition.string.perl"]
-      expect(tokens[7]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[7]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
 
-      {tokens} = grammar.tokenizeLine("s{text}{test}egimosxradlupc")
+      {tokens} = grammar.tokenizeLine("s{text}{test}acdegilmoprsux")
       expect(tokens[0]).toEqual value: "s", scopes: ["source.perl", "string.regexp.nested_braces.perl", "punctuation.definition.string.perl", "support.function.perl"]
       expect(tokens[1]).toEqual value: "{", scopes: ["source.perl", "string.regexp.nested_braces.perl", "punctuation.definition.string.perl"]
       expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.nested_braces.perl"]
@@ -134,9 +134,9 @@ describe "perl grammar", ->
       expect(tokens[4]).toEqual value: "{", scopes: ["source.perl", "string.regexp.format.nested_braces.perl", "punctuation.definition.string.perl"]
       expect(tokens[5]).toEqual value: "test", scopes: ["source.perl", "string.regexp.format.nested_braces.perl"]
       expect(tokens[6]).toEqual value: "}", scopes: ["source.perl", "string.regexp.format.nested_braces.perl", "punctuation.definition.string.perl"]
-      expect(tokens[7]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[7]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
 
-      {tokens} = grammar.tokenizeLine("s[text][test]egimosxradlupc")
+      {tokens} = grammar.tokenizeLine("s[text][test]acdegilmoprsux")
       expect(tokens[0]).toEqual value: "s", scopes: ["source.perl", "string.regexp.nested_brackets.perl", "punctuation.definition.string.perl", "support.function.perl"]
       expect(tokens[1]).toEqual value: "[", scopes: ["source.perl", "string.regexp.nested_brackets.perl", "punctuation.definition.string.perl"]
       expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.nested_brackets.perl"]
@@ -144,9 +144,9 @@ describe "perl grammar", ->
       expect(tokens[4]).toEqual value: "[", scopes: ["source.perl", "string.regexp.format.nested_brackets.perl", "punctuation.definition.string.perl"]
       expect(tokens[5]).toEqual value: "test", scopes: ["source.perl", "string.regexp.format.nested_brackets.perl"]
       expect(tokens[6]).toEqual value: "]", scopes: ["source.perl", "string.regexp.format.nested_brackets.perl", "punctuation.definition.string.perl"]
-      expect(tokens[7]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[7]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
 
-      {tokens} = grammar.tokenizeLine("s<text><test>egimosxradlupc")
+      {tokens} = grammar.tokenizeLine("s<text><test>acdegilmoprsux")
       expect(tokens[0]).toEqual value: "s", scopes: ["source.perl", "string.regexp.nested_ltgt.perl", "punctuation.definition.string.perl", "support.function.perl"]
       expect(tokens[1]).toEqual value: "<", scopes: ["source.perl", "string.regexp.nested_ltgt.perl", "punctuation.definition.string.perl"]
       expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.nested_ltgt.perl"]
@@ -154,16 +154,16 @@ describe "perl grammar", ->
       expect(tokens[4]).toEqual value: "<", scopes: ["source.perl", "string.regexp.format.nested_ltgt.perl", "punctuation.definition.string.perl"]
       expect(tokens[5]).toEqual value: "test", scopes: ["source.perl", "string.regexp.format.nested_ltgt.perl"]
       expect(tokens[6]).toEqual value: ">", scopes: ["source.perl", "string.regexp.format.nested_ltgt.perl", "punctuation.definition.string.perl"]
-      expect(tokens[7]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[7]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
 
-      {tokens} = grammar.tokenizeLine("s_text_test_egimosxradlupc")
+      {tokens} = grammar.tokenizeLine("s_text_test_acdegilmoprsux")
       expect(tokens[0]).toEqual value: "s", scopes: ["source.perl", "string.regexp.replaceXXX.simple_delimiter.perl", "punctuation.definition.string.perl", "support.function.perl"]
       expect(tokens[1]).toEqual value: "_", scopes: ["source.perl", "string.regexp.replaceXXX.simple_delimiter.perl", "punctuation.definition.string.perl"]
       expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.replaceXXX.simple_delimiter.perl"]
       expect(tokens[3]).toEqual value: "_", scopes: ["source.perl", "string.regexp.replaceXXX.format.simple_delimiter.perl", "punctuation.definition.string.perl"]
       expect(tokens[4]).toEqual value: "test", scopes: ["source.perl", "string.regexp.replaceXXX.format.simple_delimiter.perl"]
       expect(tokens[5]).toEqual value: "_", scopes: ["source.perl", "string.regexp.replaceXXX.format.simple_delimiter.perl", "punctuation.definition.string.perl"]
-      expect(tokens[6]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[6]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
 
   describe "tokenizes constant variables", ->
     it "highlights constants", ->
@@ -230,6 +230,20 @@ describe "perl grammar", ->
       {tokens} = grammar.tokenizeLine("$test->qx();")
       expect(tokens[2]).toEqual value: "->", scopes: ["source.perl", "keyword.operator.comparison.perl"]
       expect(tokens[3]).toEqual value: "qx();", scopes: ["source.perl"]
+
+  describe "when a function call tokenizes", ->
+    it "does not highlight calls which looks like a regexp", ->
+      {tokens} = grammar.tokenizeLine("s_ttest($key,\"t_storage\",$single_task);");
+      expect(tokens[0]).toEqual value: "s_ttest(", scopes: ["source.perl"]
+      expect(tokens[3]).toEqual value: ",", scopes: ["source.perl"]
+      expect(tokens[7]).toEqual value: ",", scopes: ["source.perl"]
+      expect(tokens[10]).toEqual value: ");", scopes: ["source.perl"]
+
+      {tokens} = grammar.tokenizeLine("s__ttest($key,\"t_license\",$single_task);");
+      expect(tokens[0]).toEqual value: "s__ttest(", scopes: ["source.perl"]
+      expect(tokens[3]).toEqual value: ",", scopes: ["source.perl"]
+      expect(tokens[7]).toEqual value: ",", scopes: ["source.perl"]
+      expect(tokens[10]).toEqual value: ");", scopes: ["source.perl"]
 
   describe "tokenizes single quoting", ->
     it "does not escape characters in single-quote strings", ->

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -127,6 +127,16 @@ describe "perl grammar", ->
       {tokens} = grammar.tokenizeLine("my $foo = scalar(@bar)/2;")
       expect(tokens[9]).toEqual value: ")/2;", scopes: ["source.perl"]
 
+    it "works in a if", ->
+      {tokens} = grammar.tokenizeLine("if (/ hello /i) {}")
+      expect(tokens[0]).toEqual value: "if", scopes: ["source.perl", "keyword.control.perl"]
+      expect(tokens[1]).toEqual value: " (", scopes: ["source.perl"]
+      expect(tokens[2]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
+      expect(tokens[3]).toEqual value: " hello ", scopes: ["source.perl", "string.regexp.find.perl"]
+      expect(tokens[4]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
+      expect(tokens[5]).toEqual value: "i", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[6]).toEqual value: ") {}", scopes: ["source.perl"]
+
 
   describe "when a regexp replace tokenizes", ->
     it "works with all bracket/seperator variations", ->

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -12,26 +12,158 @@ describe "perl grammar", ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe "source.perl"
 
-  describe "tokenizes regexp replace", ->
-    it "works as expected", ->
-      {tokens} = grammar.tokenizeLine("s/text/test/gxr")
+  describe "when a regexp compile tokenizes", ->
+    it "works with all bracket/seperator variations", ->
+      {tokens} = grammar.tokenizeLine("qr/text/egimosxradlupc;")
+      expect(tokens[0]).toEqual value: "qr", scopes: ["source.perl", "string.regexp.compile.simple-delimiter.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[1]).toEqual value: "/", scopes: ["source.perl", "string.regexp.compile.simple-delimiter.perl", "punctuation.definition.string.perl"]
+      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.compile.simple-delimiter.perl"]
+      expect(tokens[3]).toEqual value: "/", scopes: ["source.perl", "string.regexp.compile.simple-delimiter.perl", "punctuation.definition.string.perl"]
+      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.compile.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
+
+      {tokens} = grammar.tokenizeLine("qr(text)egimosxradlupc;")
+      expect(tokens[0]).toEqual value: "qr", scopes: ["source.perl", "string.regexp.compile.nested_parens.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[1]).toEqual value: "(", scopes: ["source.perl", "string.regexp.compile.nested_parens.perl", "punctuation.definition.string.perl"]
+      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.compile.nested_parens.perl"]
+      expect(tokens[3]).toEqual value: ")", scopes: ["source.perl", "string.regexp.compile.nested_parens.perl", "punctuation.definition.string.perl"]
+      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.compile.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
+
+      {tokens} = grammar.tokenizeLine("qr{text}egimosxradlupc;")
+      expect(tokens[0]).toEqual value: "qr", scopes: ["source.perl", "string.regexp.compile.nested_braces.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[1]).toEqual value: "{", scopes: ["source.perl", "string.regexp.compile.nested_braces.perl", "punctuation.definition.string.perl"]
+      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.compile.nested_braces.perl"]
+      expect(tokens[3]).toEqual value: "}", scopes: ["source.perl", "string.regexp.compile.nested_braces.perl", "punctuation.definition.string.perl"]
+      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.compile.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
+
+      {tokens} = grammar.tokenizeLine("qr[text]egimosxradlupc;")
+      expect(tokens[0]).toEqual value: "qr", scopes: ["source.perl", "string.regexp.compile.nested_brackets.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[1]).toEqual value: "[", scopes: ["source.perl", "string.regexp.compile.nested_brackets.perl", "punctuation.definition.string.perl"]
+      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.compile.nested_brackets.perl"]
+      expect(tokens[3]).toEqual value: "]", scopes: ["source.perl", "string.regexp.compile.nested_brackets.perl", "punctuation.definition.string.perl"]
+      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.compile.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
+
+      {tokens} = grammar.tokenizeLine("qr<text>egimosxradlupc;")
+      expect(tokens[0]).toEqual value: "qr", scopes: ["source.perl", "string.regexp.compile.nested_ltgt.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[1]).toEqual value: "<", scopes: ["source.perl", "string.regexp.compile.nested_ltgt.perl", "punctuation.definition.string.perl"]
+      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.compile.nested_ltgt.perl"]
+      expect(tokens[3]).toEqual value: ">", scopes: ["source.perl", "string.regexp.compile.nested_ltgt.perl", "punctuation.definition.string.perl"]
+      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.compile.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
+
+
+  describe "when a regexp find tokenizes", ->
+    it "works with all bracket/seperator variations", ->
+      {tokens} = grammar.tokenizeLine("/text/egimosxradlupc;")
+      expect(tokens[0]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
+      expect(tokens[1]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find.perl"]
+      expect(tokens[2]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl"]
+      expect(tokens[3]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.find.perl", "string.regexp.find.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[4]).toEqual value: ";", scopes: ["source.perl"]
+
+      {tokens} = grammar.tokenizeLine("m/text/egimosxradlupc;")
+      expect(tokens[0]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[1]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl", "punctuation.definition.string.perl"]
+      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl"]
+      expect(tokens[3]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl", "punctuation.definition.string.perl"]
+      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
+
+      {tokens} = grammar.tokenizeLine("m(text)egimosxradlupc;")
+      expect(tokens[0]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.nested_parens.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[1]).toEqual value: "(", scopes: ["source.perl", "string.regexp.find-m.nested_parens.perl", "punctuation.definition.string.perl"]
+      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.nested_parens.perl"]
+      expect(tokens[3]).toEqual value: ")", scopes: ["source.perl", "string.regexp.find-m.nested_parens.perl", "punctuation.definition.string.perl"]
+      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
+
+      {tokens} = grammar.tokenizeLine("m{text}egimosxradlupc;")
+      expect(tokens[0]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.nested_braces.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[1]).toEqual value: "{", scopes: ["source.perl", "string.regexp.find-m.nested_braces.perl", "punctuation.definition.string.perl"]
+      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.nested_braces.perl"]
+      expect(tokens[3]).toEqual value: "}", scopes: ["source.perl", "string.regexp.find-m.nested_braces.perl", "punctuation.definition.string.perl"]
+      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
+
+      {tokens} = grammar.tokenizeLine("m[text]egimosxradlupc;")
+      expect(tokens[0]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.nested_brackets.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[1]).toEqual value: "[", scopes: ["source.perl", "string.regexp.find-m.nested_brackets.perl", "punctuation.definition.string.perl"]
+      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.nested_brackets.perl"]
+      expect(tokens[3]).toEqual value: "]", scopes: ["source.perl", "string.regexp.find-m.nested_brackets.perl", "punctuation.definition.string.perl"]
+      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
+
+      {tokens} = grammar.tokenizeLine("m<text>egimosxradlupc;")
+      expect(tokens[0]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.nested_ltgt.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[1]).toEqual value: "<", scopes: ["source.perl", "string.regexp.find-m.nested_ltgt.perl", "punctuation.definition.string.perl"]
+      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.nested_ltgt.perl"]
+      expect(tokens[3]).toEqual value: ">", scopes: ["source.perl", "string.regexp.find-m.nested_ltgt.perl", "punctuation.definition.string.perl"]
+      expect(tokens[4]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
+
+
+  describe "when a regexp replace tokenizes", ->
+    it "works with all bracket/seperator variations", ->
+      {tokens} = grammar.tokenizeLine("s/text/test/egimosxradlupc")
       expect(tokens[0]).toEqual value: "s", scopes: ["source.perl", "string.regexp.replaceXXX.simple_delimiter.perl", "punctuation.definition.string.perl", "support.function.perl"]
       expect(tokens[1]).toEqual value: "/", scopes: ["source.perl", "string.regexp.replaceXXX.simple_delimiter.perl", "punctuation.definition.string.perl"]
       expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.replaceXXX.simple_delimiter.perl"]
       expect(tokens[3]).toEqual value: "/", scopes: ["source.perl", "string.regexp.replaceXXX.format.simple_delimiter.perl", "punctuation.definition.string.perl"]
       expect(tokens[4]).toEqual value: "test", scopes: ["source.perl", "string.regexp.replaceXXX.format.simple_delimiter.perl"]
       expect(tokens[5]).toEqual value: "/", scopes: ["source.perl", "string.regexp.replaceXXX.format.simple_delimiter.perl", "punctuation.definition.string.perl"]
-      expect(tokens[6]).toEqual value: "gxr", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[6]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
 
-    it "works with underline as seperator", ->
-      {tokens} = grammar.tokenizeLine("s_text_test_gxr")
+      {tokens} = grammar.tokenizeLine("s(text)(test)egimosxradlupc")
+      expect(tokens[0]).toEqual value: "s", scopes: ["source.perl", "string.regexp.nested_parens.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[1]).toEqual value: "(", scopes: ["source.perl", "string.regexp.nested_parens.perl", "punctuation.definition.string.perl"]
+      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.nested_parens.perl"]
+      expect(tokens[3]).toEqual value: ")", scopes: ["source.perl", "string.regexp.nested_parens.perl", "punctuation.definition.string.perl"]
+      expect(tokens[4]).toEqual value: "(", scopes: ["source.perl", "string.regexp.format.nested_parens.perl", "punctuation.definition.string.perl"]
+      expect(tokens[5]).toEqual value: "test", scopes: ["source.perl", "string.regexp.format.nested_parens.perl"]
+      expect(tokens[6]).toEqual value: ")", scopes: ["source.perl", "string.regexp.format.nested_parens.perl", "punctuation.definition.string.perl"]
+      expect(tokens[7]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+
+      {tokens} = grammar.tokenizeLine("s{text}{test}egimosxradlupc")
+      expect(tokens[0]).toEqual value: "s", scopes: ["source.perl", "string.regexp.nested_braces.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[1]).toEqual value: "{", scopes: ["source.perl", "string.regexp.nested_braces.perl", "punctuation.definition.string.perl"]
+      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.nested_braces.perl"]
+      expect(tokens[3]).toEqual value: "}", scopes: ["source.perl", "string.regexp.nested_braces.perl", "punctuation.definition.string.perl"]
+      expect(tokens[4]).toEqual value: "{", scopes: ["source.perl", "string.regexp.format.nested_braces.perl", "punctuation.definition.string.perl"]
+      expect(tokens[5]).toEqual value: "test", scopes: ["source.perl", "string.regexp.format.nested_braces.perl"]
+      expect(tokens[6]).toEqual value: "}", scopes: ["source.perl", "string.regexp.format.nested_braces.perl", "punctuation.definition.string.perl"]
+      expect(tokens[7]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+
+      {tokens} = grammar.tokenizeLine("s[text][test]egimosxradlupc")
+      expect(tokens[0]).toEqual value: "s", scopes: ["source.perl", "string.regexp.nested_brackets.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[1]).toEqual value: "[", scopes: ["source.perl", "string.regexp.nested_brackets.perl", "punctuation.definition.string.perl"]
+      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.nested_brackets.perl"]
+      expect(tokens[3]).toEqual value: "]", scopes: ["source.perl", "string.regexp.nested_brackets.perl", "punctuation.definition.string.perl"]
+      expect(tokens[4]).toEqual value: "[", scopes: ["source.perl", "string.regexp.format.nested_brackets.perl", "punctuation.definition.string.perl"]
+      expect(tokens[5]).toEqual value: "test", scopes: ["source.perl", "string.regexp.format.nested_brackets.perl"]
+      expect(tokens[6]).toEqual value: "]", scopes: ["source.perl", "string.regexp.format.nested_brackets.perl", "punctuation.definition.string.perl"]
+      expect(tokens[7]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+
+      {tokens} = grammar.tokenizeLine("s<text><test>egimosxradlupc")
+      expect(tokens[0]).toEqual value: "s", scopes: ["source.perl", "string.regexp.nested_ltgt.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[1]).toEqual value: "<", scopes: ["source.perl", "string.regexp.nested_ltgt.perl", "punctuation.definition.string.perl"]
+      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.nested_ltgt.perl"]
+      expect(tokens[3]).toEqual value: ">", scopes: ["source.perl", "string.regexp.nested_ltgt.perl", "punctuation.definition.string.perl"]
+      expect(tokens[4]).toEqual value: "<", scopes: ["source.perl", "string.regexp.format.nested_ltgt.perl", "punctuation.definition.string.perl"]
+      expect(tokens[5]).toEqual value: "test", scopes: ["source.perl", "string.regexp.format.nested_ltgt.perl"]
+      expect(tokens[6]).toEqual value: ">", scopes: ["source.perl", "string.regexp.format.nested_ltgt.perl", "punctuation.definition.string.perl"]
+      expect(tokens[7]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+
+      {tokens} = grammar.tokenizeLine("s_text_test_egimosxradlupc")
       expect(tokens[0]).toEqual value: "s", scopes: ["source.perl", "string.regexp.replaceXXX.simple_delimiter.perl", "punctuation.definition.string.perl", "support.function.perl"]
       expect(tokens[1]).toEqual value: "_", scopes: ["source.perl", "string.regexp.replaceXXX.simple_delimiter.perl", "punctuation.definition.string.perl"]
       expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.replaceXXX.simple_delimiter.perl"]
       expect(tokens[3]).toEqual value: "_", scopes: ["source.perl", "string.regexp.replaceXXX.format.simple_delimiter.perl", "punctuation.definition.string.perl"]
       expect(tokens[4]).toEqual value: "test", scopes: ["source.perl", "string.regexp.replaceXXX.format.simple_delimiter.perl"]
       expect(tokens[5]).toEqual value: "_", scopes: ["source.perl", "string.regexp.replaceXXX.format.simple_delimiter.perl", "punctuation.definition.string.perl"]
-      expect(tokens[6]).toEqual value: "gxr", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[6]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.replace.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
 
   describe "tokenizes constant variables", ->
     it "highlights constants", ->

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -57,53 +57,71 @@ describe "perl grammar", ->
 
   describe "when a regexp find tokenizes", ->
     it "works with all bracket/seperator variations", ->
-      {tokens} = grammar.tokenizeLine("/text/acdegilmoprsux;")
-      expect(tokens[0]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
-      expect(tokens[1]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find.perl"]
+      {tokens} = grammar.tokenizeLine(" =~ /text/acdegilmoprsux;")
+      expect(tokens[0]).toEqual value: " =~", scopes: ["source.perl"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.perl", "string.regexp.find.perl"]
       expect(tokens[2]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
-      expect(tokens[3]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
-      expect(tokens[4]).toEqual value: ";", scopes: ["source.perl"]
+      expect(tokens[3]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find.perl"]
+      expect(tokens[4]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
+      expect(tokens[5]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[6]).toEqual value: ";", scopes: ["source.perl"]
 
-      {tokens} = grammar.tokenizeLine("m/text/acdegilmoprsux;")
-      expect(tokens[0]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl", "punctuation.definition.string.perl", "support.function.perl"]
-      expect(tokens[1]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl", "punctuation.definition.string.perl"]
-      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl"]
-      expect(tokens[3]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl", "punctuation.definition.string.perl"]
-      expect(tokens[4]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
-      expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
+      {tokens} = grammar.tokenizeLine(" =~ m/text/acdegilmoprsux;")
+      expect(tokens[0]).toEqual value: " =~ ", scopes: ["source.perl"]
+      expect(tokens[1]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[2]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl", "punctuation.definition.string.perl"]
+      expect(tokens[3]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl"]
+      expect(tokens[4]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl", "punctuation.definition.string.perl"]
+      expect(tokens[5]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[6]).toEqual value: ";", scopes: ["source.perl"]
 
-      {tokens} = grammar.tokenizeLine("m(text)acdegilmoprsux;")
-      expect(tokens[0]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.nested_parens.perl", "punctuation.definition.string.perl", "support.function.perl"]
-      expect(tokens[1]).toEqual value: "(", scopes: ["source.perl", "string.regexp.find-m.nested_parens.perl", "punctuation.definition.string.perl"]
-      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.nested_parens.perl"]
-      expect(tokens[3]).toEqual value: ")", scopes: ["source.perl", "string.regexp.find-m.nested_parens.perl", "punctuation.definition.string.perl"]
-      expect(tokens[4]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
-      expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
+      {tokens} = grammar.tokenizeLine(" =~ m(text)acdegilmoprsux;")
+      expect(tokens[0]).toEqual value: " =~ ", scopes: ["source.perl"]
+      expect(tokens[1]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.nested_parens.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[2]).toEqual value: "(", scopes: ["source.perl", "string.regexp.find-m.nested_parens.perl", "punctuation.definition.string.perl"]
+      expect(tokens[3]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.nested_parens.perl"]
+      expect(tokens[4]).toEqual value: ")", scopes: ["source.perl", "string.regexp.find-m.nested_parens.perl", "punctuation.definition.string.perl"]
+      expect(tokens[5]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[6]).toEqual value: ";", scopes: ["source.perl"]
 
-      {tokens} = grammar.tokenizeLine("m{text}acdegilmoprsux;")
-      expect(tokens[0]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.nested_braces.perl", "punctuation.definition.string.perl", "support.function.perl"]
-      expect(tokens[1]).toEqual value: "{", scopes: ["source.perl", "string.regexp.find-m.nested_braces.perl", "punctuation.definition.string.perl"]
-      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.nested_braces.perl"]
-      expect(tokens[3]).toEqual value: "}", scopes: ["source.perl", "string.regexp.find-m.nested_braces.perl", "punctuation.definition.string.perl"]
-      expect(tokens[4]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
-      expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
+      {tokens} = grammar.tokenizeLine(" =~ m{text}acdegilmoprsux;")
+      expect(tokens[0]).toEqual value: " =~ ", scopes: ["source.perl"]
+      expect(tokens[1]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.nested_braces.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[2]).toEqual value: "{", scopes: ["source.perl", "string.regexp.find-m.nested_braces.perl", "punctuation.definition.string.perl"]
+      expect(tokens[3]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.nested_braces.perl"]
+      expect(tokens[4]).toEqual value: "}", scopes: ["source.perl", "string.regexp.find-m.nested_braces.perl", "punctuation.definition.string.perl"]
+      expect(tokens[5]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[6]).toEqual value: ";", scopes: ["source.perl"]
 
-      {tokens} = grammar.tokenizeLine("m[text]acdegilmoprsux;")
-      expect(tokens[0]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.nested_brackets.perl", "punctuation.definition.string.perl", "support.function.perl"]
-      expect(tokens[1]).toEqual value: "[", scopes: ["source.perl", "string.regexp.find-m.nested_brackets.perl", "punctuation.definition.string.perl"]
-      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.nested_brackets.perl"]
-      expect(tokens[3]).toEqual value: "]", scopes: ["source.perl", "string.regexp.find-m.nested_brackets.perl", "punctuation.definition.string.perl"]
-      expect(tokens[4]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
-      expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
+      {tokens} = grammar.tokenizeLine(" =~ m[text]acdegilmoprsux;")
+      expect(tokens[0]).toEqual value: " =~ ", scopes: ["source.perl"]
+      expect(tokens[1]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.nested_brackets.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[2]).toEqual value: "[", scopes: ["source.perl", "string.regexp.find-m.nested_brackets.perl", "punctuation.definition.string.perl"]
+      expect(tokens[3]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.nested_brackets.perl"]
+      expect(tokens[4]).toEqual value: "]", scopes: ["source.perl", "string.regexp.find-m.nested_brackets.perl", "punctuation.definition.string.perl"]
+      expect(tokens[5]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[6]).toEqual value: ";", scopes: ["source.perl"]
 
-      {tokens} = grammar.tokenizeLine("m<text>acdegilmoprsux;")
-      expect(tokens[0]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.nested_ltgt.perl", "punctuation.definition.string.perl", "support.function.perl"]
-      expect(tokens[1]).toEqual value: "<", scopes: ["source.perl", "string.regexp.find-m.nested_ltgt.perl", "punctuation.definition.string.perl"]
-      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.nested_ltgt.perl"]
-      expect(tokens[3]).toEqual value: ">", scopes: ["source.perl", "string.regexp.find-m.nested_ltgt.perl", "punctuation.definition.string.perl"]
-      expect(tokens[4]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
-      expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
+      {tokens} = grammar.tokenizeLine(" =~ m<text>acdegilmoprsux;")
+      expect(tokens[0]).toEqual value: " =~ ", scopes: ["source.perl"]
+      expect(tokens[1]).toEqual value: "m", scopes: ["source.perl", "string.regexp.find-m.nested_ltgt.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[2]).toEqual value: "<", scopes: ["source.perl", "string.regexp.find-m.nested_ltgt.perl", "punctuation.definition.string.perl"]
+      expect(tokens[3]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find-m.nested_ltgt.perl"]
+      expect(tokens[4]).toEqual value: ">", scopes: ["source.perl", "string.regexp.find-m.nested_ltgt.perl", "punctuation.definition.string.perl"]
+      expect(tokens[5]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[6]).toEqual value: ";", scopes: ["source.perl"]
 
+    it "works with multiline regexp", ->
+      lines = grammar.tokenizeLines("""$asd =~ /
+      (\\d)
+      /x""")
+      expect(lines[0][2]).toEqual value: " =~", scopes: ["source.perl"]
+      expect(lines[0][3]).toEqual value: " ", scopes: ["source.perl", "string.regexp.find.perl"]
+      expect(lines[0][4]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
+      expect(lines[1][0]).toEqual value: "(", scopes: ["source.perl", "string.regexp.find.perl"]
+      expect(lines[1][2]).toEqual value: ")", scopes: ["source.perl", "string.regexp.find.perl"]
+      expect(lines[2][0]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
+      expect(lines[2][1]).toEqual value: "x", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
 
   describe "when a regexp replace tokenizes", ->
     it "works with all bracket/seperator variations", ->

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -129,13 +129,20 @@ describe "perl grammar", ->
 
     it "works in a if", ->
       {tokens} = grammar.tokenizeLine("if (/ hello /i) {}")
-      expect(tokens[0]).toEqual value: "if", scopes: ["source.perl", "keyword.control.perl"]
       expect(tokens[1]).toEqual value: " (", scopes: ["source.perl"]
       expect(tokens[2]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
       expect(tokens[3]).toEqual value: " hello ", scopes: ["source.perl", "string.regexp.find.perl"]
       expect(tokens[4]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
       expect(tokens[5]).toEqual value: "i", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
       expect(tokens[6]).toEqual value: ") {}", scopes: ["source.perl"]
+
+      {tokens} = grammar.tokenizeLine("if ($_ && / hello /i) {}")
+      expect(tokens[5]).toEqual value: " ", scopes: ["source.perl"]
+      expect(tokens[6]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
+      expect(tokens[7]).toEqual value: " hello ", scopes: ["source.perl", "string.regexp.find.perl"]
+      expect(tokens[8]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
+      expect(tokens[9]).toEqual value: "i", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[10]).toEqual value: ") {}", scopes: ["source.perl"]
 
 
   describe "when a regexp replace tokenizes", ->

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -60,8 +60,8 @@ describe "perl grammar", ->
       {tokens} = grammar.tokenizeLine("/text/egimosxradlupc;")
       expect(tokens[0]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
       expect(tokens[1]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find.perl"]
-      expect(tokens[2]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl"]
-      expect(tokens[3]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.find.perl", "string.regexp.find.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[2]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
+      expect(tokens[3]).toEqual value: "egimosxradlupc", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
       expect(tokens[4]).toEqual value: ";", scopes: ["source.perl"]
 
       {tokens} = grammar.tokenizeLine("m/text/egimosxradlupc;")

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -59,7 +59,7 @@ describe "perl grammar", ->
     it "works with all bracket/seperator variations", ->
       {tokens} = grammar.tokenizeLine(" =~ /text/acdegilmoprsux;")
       expect(tokens[0]).toEqual value: " =~", scopes: ["source.perl"]
-      expect(tokens[1]).toEqual value: " ", scopes: ["source.perl", "string.regexp.find.perl"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.perl"]
       expect(tokens[2]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
       expect(tokens[3]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find.perl"]
       expect(tokens[4]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
@@ -116,12 +116,17 @@ describe "perl grammar", ->
       (\\d)
       /x""")
       expect(lines[0][2]).toEqual value: " =~", scopes: ["source.perl"]
-      expect(lines[0][3]).toEqual value: " ", scopes: ["source.perl", "string.regexp.find.perl"]
+      expect(lines[0][3]).toEqual value: " ", scopes: ["source.perl"]
       expect(lines[0][4]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
       expect(lines[1][0]).toEqual value: "(", scopes: ["source.perl", "string.regexp.find.perl"]
       expect(lines[1][2]).toEqual value: ")", scopes: ["source.perl", "string.regexp.find.perl"]
       expect(lines[2][0]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
       expect(lines[2][1]).toEqual value: "x", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+
+    it "does not highlight a divide operation", ->
+      {tokens} = grammar.tokenizeLine("my $foo = scalar(@bar)/2;")
+      expect(tokens[9]).toEqual value: ")/2;", scopes: ["source.perl"]
+
 
   describe "when a regexp replace tokenizes", ->
     it "works with all bracket/seperator variations", ->


### PR DESCRIPTION
I tried to combine all regex blocks to handle/show the same behaviour.

This fixes #6, #20, #21, https://github.com/textmate/perl.tmbundle/issues/1

![regex_rewrite](https://cloud.githubusercontent.com/assets/1900106/6691192/8040aec2-ccc5-11e4-9137-cd083c268158.PNG)
1. Same behaviour in all cases (`m`, `s`, `qr`, or none)
2. won't break out anymore (divide issue)
3. works with $_ variable in most cases (can't say all because i only tested all cases i know)
4. Added multiline regex support (http://perldoc.perl.org/perlre.html#Repeated-Patterns-Matching-a-Zero-length-Substring)
5. `m` now support `_` characters

```perl
 =~ /\r\n|\r|\n/g;
$test =~ /\r\n|\r|\n/g;
$test =~ m/\r\n|\r|\n/g;
$test =~ m~\r\n|\r|\n~g;
$test =~ m(\r\n|\r|\n)g;
$test =~ m[\r\n|\r|\n]g;
$test =~ m{\r\n|\r|\n}g;

$test =~ s/\r\n|\r|\n/\r\n/g;
$test =~ s~\r\n|\r|\n~\r\n~g;
$test =~ s(\r\n|\r|\n)(\r\n)g;
$test =~ s[\r\n|\r|\n][\r\n]g;
$test =~ s{\r\n|\r|\n}{\r\n}g;
$test =~ s<\r\n|\r|\n><\r\n>g;

my $foo = scalar(@bar)/2;

print '<table>' . join("\n", (@trs)[0..(scalar(@trs)/ 2)]) . '</table>';


if (/ Check \s (Mate)/x) {
	asd
}

$_ = " Hello World ";
if ($_ && / hello /i) {
	print "foo";
}

$asd =~ /
asdasd
/x;

m_asd_i;
```