### PR TITLE
Heredoc rewrite

### DIFF
--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -1099,6 +1099,24 @@
     'end': '(^\\4$)'
   }
   {
+    'begin': '(((<<) *\\\\((?![=\\d\\$\\( ])[^;,\'"`\\s\\)]*)))(.*)\\n?'
+    'captures':
+      '1':
+        'name': 'punctuation.definition.string.perl'
+      '2':
+        'name': 'string.unquoted.heredoc.quote.perl'
+      '3':
+        'name': 'punctuation.definition.heredoc.perl'
+      '5':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
+    'contentName': 'string.unquoted.heredoc.quote.perl'
+    'end': '(^\\4$)'
+  }
+  {
     'begin': '(((<<) *`([^`]*)`))(.*)\\n?'
     'captures':
       '1':

--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -800,6 +800,35 @@
       }
     ]
   }
+  # {
+  #   'begin': '(((<<) *"CSS"))(.*)\\n?'
+  #   'captures':
+  #     '1':
+  #       'name': 'punctuation.definition.string.perl'
+  #     '2':
+  #       'name': 'string.unquoted.heredoc.doublequote.perl'
+  #     '3':
+  #       'name': 'punctuation.definition.heredoc.perl'
+  #     '4':
+  #       'patterns': [
+  #         {
+  #           'include': '$self'
+  #         }
+  #       ]
+  #   'contentName': 'text.css.embedded.perl'
+  #   'end': '(^CSS$)'
+  #   'patterns': [
+  #     {
+  #       'include': '#escaped_char'
+  #     }
+  #     {
+  #       'include': '#variable'
+  #     }
+  #     {
+  #       'include': 'source.css'
+  #     }
+  #   ]
+  # }
   {
     'begin': '(((<<) *"JAVASCRIPT"))(.*)\\n?'
     'captures':
@@ -959,6 +988,29 @@
       }
     ]
   }
+  # {
+  #   'begin': '(((<<) *\'CSS\'))(.*)\\n?'
+  #   'captures':
+  #     '1':
+  #       'name': 'punctuation.definition.string.perl'
+  #     '2':
+  #       'name': 'string.unquoted.heredoc.quote.perl'
+  #     '3':
+  #       'name': 'punctuation.definition.heredoc.perl'
+  #     '4':
+  #       'patterns': [
+  #         {
+  #           'include': '$self'
+  #         }
+  #       ]
+  #   'contentName': 'text.css.embedded.perl'
+  #   'end': '(^CSS$)'
+  #   'patterns': [
+  #     {
+  #       'include': 'source.css'
+  #     }
+  #   ]
+  # }
   {
     'begin': '(((<<) *\'JAVASCRIPT\'))(.*)\\n?'
     'captures':

--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -800,35 +800,35 @@
       }
     ]
   }
-  # {
-  #   'begin': '(((<<) *"CSS"))(.*)\\n?'
-  #   'captures':
-  #     '1':
-  #       'name': 'punctuation.definition.string.perl'
-  #     '2':
-  #       'name': 'string.unquoted.heredoc.doublequote.perl'
-  #     '3':
-  #       'name': 'punctuation.definition.heredoc.perl'
-  #     '4':
-  #       'patterns': [
-  #         {
-  #           'include': '$self'
-  #         }
-  #       ]
-  #   'contentName': 'text.css.embedded.perl'
-  #   'end': '(^CSS$)'
-  #   'patterns': [
-  #     {
-  #       'include': '#escaped_char'
-  #     }
-  #     {
-  #       'include': '#variable'
-  #     }
-  #     {
-  #       'include': 'source.css'
-  #     }
-  #   ]
-  # }
+  {
+    'begin': '(((<<) *"CSS"))(.*)\\n?'
+    'captures':
+      '1':
+        'name': 'punctuation.definition.string.perl'
+      '2':
+        'name': 'string.unquoted.heredoc.doublequote.perl'
+      '3':
+        'name': 'punctuation.definition.heredoc.perl'
+      '4':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
+    'contentName': 'text.css.embedded.perl'
+    'end': '(^CSS$)'
+    'patterns': [
+      {
+        'include': '#escaped_char'
+      }
+      {
+        'include': '#variable'
+      }
+      {
+        'include': 'source.css'
+      }
+    ]
+  }
   {
     'begin': '(((<<) *"JAVASCRIPT"))(.*)\\n?'
     'captures':
@@ -988,29 +988,29 @@
       }
     ]
   }
-  # {
-  #   'begin': '(((<<) *\'CSS\'))(.*)\\n?'
-  #   'captures':
-  #     '1':
-  #       'name': 'punctuation.definition.string.perl'
-  #     '2':
-  #       'name': 'string.unquoted.heredoc.quote.perl'
-  #     '3':
-  #       'name': 'punctuation.definition.heredoc.perl'
-  #     '4':
-  #       'patterns': [
-  #         {
-  #           'include': '$self'
-  #         }
-  #       ]
-  #   'contentName': 'text.css.embedded.perl'
-  #   'end': '(^CSS$)'
-  #   'patterns': [
-  #     {
-  #       'include': 'source.css'
-  #     }
-  #   ]
-  # }
+  {
+    'begin': '(((<<) *\'CSS\'))(.*)\\n?'
+    'captures':
+      '1':
+        'name': 'punctuation.definition.string.perl'
+      '2':
+        'name': 'string.unquoted.heredoc.quote.perl'
+      '3':
+        'name': 'punctuation.definition.heredoc.perl'
+      '4':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
+    'contentName': 'text.css.embedded.perl'
+    'end': '(^CSS$)'
+    'patterns': [
+      {
+        'include': 'source.css'
+      }
+    ]
+  }
   {
     'begin': '(((<<) *\'JAVASCRIPT\'))(.*)\\n?'
     'captures':

--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -800,35 +800,6 @@
       }
     ]
   }
-  # {
-  #   'begin': '(((<<) *"CSS"))(.*)\\n?'
-  #   'captures':
-  #     '1':
-  #       'name': 'punctuation.definition.string.perl'
-  #     '2':
-  #       'name': 'string.unquoted.heredoc.doublequote.perl'
-  #     '3':
-  #       'name': 'punctuation.definition.heredoc.perl'
-  #     '4':
-  #       'patterns': [
-  #         {
-  #           'include': '$self'
-  #         }
-  #       ]
-  #   'contentName': 'text.css.embedded.perl'
-  #   'end': '(^CSS$)'
-  #   'patterns': [
-  #     {
-  #       'include': '#escaped_char'
-  #     }
-  #     {
-  #       'include': '#variable'
-  #     }
-  #     {
-  #       'include': 'source.css'
-  #     }
-  #   ]
-  # }
   {
     'begin': '(((<<) *"JAVASCRIPT"))(.*)\\n?'
     'captures':
@@ -988,29 +959,6 @@
       }
     ]
   }
-  # {
-  #   'begin': '(((<<) *\'CSS\'))(.*)\\n?'
-  #   'captures':
-  #     '1':
-  #       'name': 'punctuation.definition.string.perl'
-  #     '2':
-  #       'name': 'string.unquoted.heredoc.quote.perl'
-  #     '3':
-  #       'name': 'punctuation.definition.heredoc.perl'
-  #     '4':
-  #       'patterns': [
-  #         {
-  #           'include': '$self'
-  #         }
-  #       ]
-  #   'contentName': 'text.css.embedded.perl'
-  #   'end': '(^CSS$)'
-  #   'patterns': [
-  #     {
-  #       'include': 'source.css'
-  #     }
-  #   ]
-  # }
   {
     'begin': '(((<<) *\'JAVASCRIPT\'))(.*)\\n?'
     'captures':

--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -743,14 +743,20 @@
     'name': 'keyword.operator.comparison.perl'
   }
   {
-    'begin': '((<<) *"HTML").*\\n?'
+    'begin': '(((<<) *"HTML"))(.*)\\n?'
     'captures':
-      '0':
-        'name': 'punctuation.definition.string.perl'
       '1':
-        'name': 'string.unquoted.heredoc.doublequote.perl'
+        'name': 'punctuation.definition.string.perl'
       '2':
+        'name': 'string.unquoted.heredoc.doublequote.perl'
+      '3':
         'name': 'punctuation.definition.heredoc.perl'
+      '4':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
     'contentName': 'text.html.embedded.perl'
     'end': '(^HTML$)'
     'patterns': [
@@ -766,14 +772,20 @@
     ]
   }
   {
-    'begin': '((<<) *"XML").*\\n?'
+    'begin': '(((<<) *"XML"))(.*)\\n?'
     'captures':
-      '0':
-        'name': 'punctuation.definition.string.perl'
       '1':
-        'name': 'string.unquoted.heredoc.doublequote.perl'
+        'name': 'punctuation.definition.string.perl'
       '2':
+        'name': 'string.unquoted.heredoc.doublequote.perl'
+      '3':
         'name': 'punctuation.definition.heredoc.perl'
+      '4':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
     'contentName': 'text.xml.embedded.perl'
     'end': '(^XML$)'
     'patterns': [
@@ -788,38 +800,50 @@
       }
     ]
   }
+  # {
+  #   'begin': '(((<<) *"CSS"))(.*)\\n?'
+  #   'captures':
+  #     '1':
+  #       'name': 'punctuation.definition.string.perl'
+  #     '2':
+  #       'name': 'string.unquoted.heredoc.doublequote.perl'
+  #     '3':
+  #       'name': 'punctuation.definition.heredoc.perl'
+  #     '4':
+  #       'patterns': [
+  #         {
+  #           'include': '$self'
+  #         }
+  #       ]
+  #   'contentName': 'text.css.embedded.perl'
+  #   'end': '(^CSS$)'
+  #   'patterns': [
+  #     {
+  #       'include': '#escaped_char'
+  #     }
+  #     {
+  #       'include': '#variable'
+  #     }
+  #     {
+  #       'include': 'source.css'
+  #     }
+  #   ]
+  # }
   {
-    'begin': '((<<) *"CSS").*\\n?'
+    'begin': '(((<<) *"JAVASCRIPT"))(.*)\\n?'
     'captures':
-      '0':
-        'name': 'punctuation.definition.string.perl'
       '1':
-        'name': 'string.unquoted.heredoc.doublequote.perl'
-      '2':
-        'name': 'punctuation.definition.heredoc.perl'
-    'contentName': 'text.css.embedded.perl'
-    'end': '(^CSS$)'
-    'patterns': [
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#variable'
-      }
-      {
-        'include': 'source.css'
-      }
-    ]
-  }
-  {
-    'begin': '((<<) *"JAVASCRIPT").*\\n?'
-    'captures':
-      '0':
         'name': 'punctuation.definition.string.perl'
-      '1':
-        'name': 'string.unquoted.heredoc.doublequote.perl'
       '2':
+        'name': 'string.unquoted.heredoc.doublequote.perl'
+      '3':
         'name': 'punctuation.definition.heredoc.perl'
+      '4':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
     'contentName': 'text.js.embedded.perl'
     'end': '(^JAVASCRIPT$)'
     'patterns': [
@@ -835,14 +859,20 @@
     ]
   }
   {
-    'begin': '((<<) *"SQL").*\\n?'
+    'begin': '(((<<) *"SQL"))(.*)\\n?'
     'captures':
-      '0':
-        'name': 'punctuation.definition.string.perl'
       '1':
-        'name': 'string.unquoted.heredoc.doublequote.perl'
+        'name': 'punctuation.definition.string.perl'
       '2':
+        'name': 'string.unquoted.heredoc.doublequote.perl'
+      '3':
         'name': 'punctuation.definition.heredoc.perl'
+      '4':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
     'contentName': 'source.sql.embedded.perl'
     'end': '(^SQL$)'
     'patterns': [
@@ -858,14 +888,20 @@
     ]
   }
   {
-    'begin': '((<<) *"POSTSCRIPT").*\\n?'
+    'begin': '(((<<) *"POSTSCRIPT"))(.*)\\n?'
     'captures':
-      '0':
-        'name': 'punctuation.definition.string.perl'
       '1':
-        'name': 'string.unquoted.heredoc.doublequote.perl'
+        'name': 'punctuation.definition.string.perl'
       '2':
+        'name': 'string.unquoted.heredoc.doublequote.perl'
+      '3':
         'name': 'punctuation.definition.heredoc.perl'
+      '4':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
     'contentName': 'text.postscript.embedded.perl'
     'end': '(^POSTSCRIPT$)'
     'patterns': [
@@ -881,16 +917,22 @@
     ]
   }
   {
-    'begin': '((<<) *"([^"]*)").*\\n?'
+    'begin': '(((<<) *"([^"]*)"))(.*)\\n?'
     'captures':
-      '0':
-        'name': 'punctuation.definition.string.perl'
       '1':
-        'name': 'string.unquoted.heredoc.doublequote.perl'
+        'name': 'punctuation.definition.string.perl'
       '2':
+        'name': 'string.unquoted.heredoc.doublequote.perl'
+      '3':
         'name': 'punctuation.definition.heredoc.perl'
+      '5':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
     'contentName': 'string.unquoted.heredoc.doublequote.perl'
-    'end': '(^\\3$)'
+    'end': '(^\\4$)'
     'patterns': [
       {
         'include': '#escaped_char'
@@ -901,14 +943,20 @@
     ]
   }
   {
-    'begin': '((<<) *\'HTML\').*\\n?'
+    'begin': '(((<<) *\'HTML\'))(.*)\\n?'
     'captures':
-      '0':
-        'name': 'punctuation.definition.string.perl'
       '1':
-        'name': 'string.unquoted.heredoc.quote.perl'
+        'name': 'punctuation.definition.string.perl'
       '2':
+        'name': 'string.unquoted.heredoc.quote.perl'
+      '3':
         'name': 'punctuation.definition.heredoc.perl'
+      '4':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
     'contentName': 'text.html.embedded.perl'
     'end': '(^HTML$)'
     'patterns': [
@@ -918,14 +966,20 @@
     ]
   }
   {
-    'begin': '((<<) *\'XML\').*\\n?'
+    'begin': '(((<<) *\'XML\'))(.*)\\n?'
     'captures':
-      '0':
-        'name': 'punctuation.definition.string.perl'
       '1':
-        'name': 'string.unquoted.heredoc.quote.perl'
+        'name': 'punctuation.definition.string.perl'
       '2':
+        'name': 'string.unquoted.heredoc.quote.perl'
+      '3':
         'name': 'punctuation.definition.heredoc.perl'
+      '4':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
     'contentName': 'text.xml.embedded.perl'
     'end': '(^XML$)'
     'patterns': [
@@ -934,32 +988,44 @@
       }
     ]
   }
+  # {
+  #   'begin': '(((<<) *\'CSS\'))(.*)\\n?'
+  #   'captures':
+  #     '1':
+  #       'name': 'punctuation.definition.string.perl'
+  #     '2':
+  #       'name': 'string.unquoted.heredoc.quote.perl'
+  #     '3':
+  #       'name': 'punctuation.definition.heredoc.perl'
+  #     '4':
+  #       'patterns': [
+  #         {
+  #           'include': '$self'
+  #         }
+  #       ]
+  #   'contentName': 'text.css.embedded.perl'
+  #   'end': '(^CSS$)'
+  #   'patterns': [
+  #     {
+  #       'include': 'source.css'
+  #     }
+  #   ]
+  # }
   {
-    'begin': '((<<) *\'CSS\').*\\n?'
+    'begin': '(((<<) *\'JAVASCRIPT\'))(.*)\\n?'
     'captures':
-      '0':
-        'name': 'punctuation.definition.string.perl'
       '1':
-        'name': 'string.unquoted.heredoc.quote.perl'
-      '2':
-        'name': 'punctuation.definition.heredoc.perl'
-    'contentName': 'text.css.embedded.perl'
-    'end': '(^CSS$)'
-    'patterns': [
-      {
-        'include': 'source.css'
-      }
-    ]
-  }
-  {
-    'begin': '((<<) *\'JAVASCRIPT\').*\\n?'
-    'captures':
-      '0':
         'name': 'punctuation.definition.string.perl'
-      '1':
-        'name': 'string.unquoted.heredoc.quote.perl'
       '2':
+        'name': 'string.unquoted.heredoc.quote.perl'
+      '3':
         'name': 'punctuation.definition.heredoc.perl'
+      '4':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
     'contentName': 'text.js.embedded.perl'
     'end': '(^JAVASCRIPT$)'
     'patterns': [
@@ -969,14 +1035,20 @@
     ]
   }
   {
-    'begin': '((<<) *\'SQL\').*\\n?'
+    'begin': '(((<<) *\'SQL\'))(.*)\\n?'
     'captures':
-      '0':
-        'name': 'punctuation.definition.string.perl'
       '1':
-        'name': 'string.unquoted.heredoc.quote.perl'
+        'name': 'punctuation.definition.string.perl'
       '2':
+        'name': 'string.unquoted.heredoc.quote.perl'
+      '3':
         'name': 'punctuation.definition.heredoc.perl'
+      '4':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
     'contentName': 'source.sql.embedded.perl'
     'end': '(^SQL$)'
     'patterns': [
@@ -986,14 +1058,20 @@
     ]
   }
   {
-    'begin': '((<<) *\'POSTSCRIPT\').*\\n?'
+    'begin': '(((<<) *\'POSTSCRIPT\'))(.*)\\n?'
     'captures':
-      '0':
-        'name': 'punctuation.definition.string.perl'
       '1':
-        'name': 'string.unquoted.heredoc.quote.perl'
+        'name': 'punctuation.definition.string.perl'
       '2':
+        'name': 'string.unquoted.heredoc.quote.perl'
+      '3':
         'name': 'punctuation.definition.heredoc.perl'
+      '4':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
     'contentName': 'source.postscript.embedded.perl'
     'end': '(^POSTSCRIPT)'
     'patterns': [
@@ -1003,28 +1081,40 @@
     ]
   }
   {
-    'begin': '((<<) *\'([^\']*)\').*\\n?'
+    'begin': '(((<<) *\'([^\']*)\'))(.*)\\n?'
     'captures':
-      '0':
-        'name': 'punctuation.definition.string.perl'
       '1':
-        'name': 'string.unquoted.heredoc.quote.perl'
+        'name': 'punctuation.definition.string.perl'
       '2':
+        'name': 'string.unquoted.heredoc.quote.perl'
+      '3':
         'name': 'punctuation.definition.heredoc.perl'
+      '5':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
     'contentName': 'string.unquoted.heredoc.quote.perl'
-    'end': '(^\\3$)'
+    'end': '(^\\4$)'
   }
   {
-    'begin': '((<<) *`([^`]*)`).*\\n?'
+    'begin': '(((<<) *`([^`]*)`))(.*)\\n?'
     'captures':
-      '0':
-        'name': 'punctuation.definition.string.perl'
       '1':
-        'name': 'string.unquoted.heredoc.backtick.perl'
+        'name': 'punctuation.definition.string.perl'
       '2':
+        'name': 'string.unquoted.heredoc.backtick.perl'
+      '3':
         'name': 'punctuation.definition.heredoc.perl'
+      '5':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
     'contentName': 'string.unquoted.heredoc.backtick.perl'
-    'end': '(^\\3$)'
+    'end': '(^\\4$)'
     'patterns': [
       {
         'include': '#escaped_char'
@@ -1035,14 +1125,20 @@
     ]
   }
   {
-    'begin': '((<<) *HTML\\b).*\\n?'
+    'begin': '(((<<) *HTML\\b))(.*)\\n?'
     'captures':
-      '0':
-        'name': 'punctuation.definition.string.perl'
       '1':
-        'name': 'string.unquoted.heredoc.perl'
+        'name': 'punctuation.definition.string.perl'
       '2':
+        'name': 'string.unquoted.heredoc.perl'
+      '3':
         'name': 'punctuation.definition.heredoc.perl'
+      '4':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
     'contentName': 'text.html.embedded.perl'
     'end': '(^HTML$)'
     'patterns': [
@@ -1058,14 +1154,20 @@
     ]
   }
   {
-    'begin': '((<<) *XML\\b).*\\n?'
+    'begin': '(((<<) *XML\\b))(.*)\\n?'
     'captures':
-      '0':
-        'name': 'punctuation.definition.string.perl'
       '1':
-        'name': 'string.unquoted.heredoc.perl'
+        'name': 'punctuation.definition.string.perl'
       '2':
+        'name': 'string.unquoted.heredoc.perl'
+      '3':
         'name': 'punctuation.definition.heredoc.perl'
+      '4':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
     'contentName': 'text.xml.embedded.perl'
     'end': '(^XML$)'
     'patterns': [
@@ -1081,14 +1183,49 @@
     ]
   }
   {
-    'begin': '((<<) *SQL\\b).*\\n?'
+    'begin': '(((<<) *JAVASCRIPT\\b))(.*)\\n?'
     'captures':
-      '0':
-        'name': 'punctuation.definition.string.perl'
       '1':
-        'name': 'string.unquoted.heredoc.perl'
+        'name': 'punctuation.definition.string.perl'
       '2':
+        'name': 'string.unquoted.heredoc.perl'
+      '3':
         'name': 'punctuation.definition.heredoc.perl'
+      '4':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
+    'contentName': 'text.js.embedded.perl'
+    'end': '(^JAVASCRIPT$)'
+    'patterns': [
+      {
+        'include': '#escaped_char'
+      }
+      {
+        'include': '#variable'
+      }
+      {
+        'include': 'source.js'
+      }
+    ]
+  }
+  {
+    'begin': '(((<<) *SQL\\b))(.*)\\n?'
+    'captures':
+      '1':
+        'name': 'punctuation.definition.string.perl'
+      '2':
+        'name': 'string.unquoted.heredoc.perl'
+      '3':
+        'name': 'punctuation.definition.heredoc.perl'
+      '4':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
     'contentName': 'source.sql.embedded.perl'
     'end': '(^SQL$)'
     'patterns': [
@@ -1104,14 +1241,20 @@
     ]
   }
   {
-    'begin': '((<<) *POSTSCRIPT\\b).*\\n?'
+    'begin': '(((<<) *POSTSCRIPT\\b))(.*)\\n?'
     'captures':
-      '0':
-        'name': 'punctuation.definition.string.perl'
       '1':
-        'name': 'string.unquoted.heredoc.perl'
+        'name': 'punctuation.definition.string.perl'
       '2':
+        'name': 'string.unquoted.heredoc.perl'
+      '3':
         'name': 'punctuation.definition.heredoc.perl'
+      '4':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
     'contentName': 'source.postscript.embedded.perl'
     'end': '(^POSTSCRIPT)'
     'patterns': [
@@ -1127,16 +1270,22 @@
     ]
   }
   {
-    'begin': '((<<) *((?![=\\d\\$\\( ])[^;,\'"`\\s)]*)).*\\n?'
+    'begin': '(((<<) *((?![=\\d\\$\\( ])[^;,\'"`\\s\\)]*)))(.*)\\n?'
     'captures':
-      '0':
-        'name': 'punctuation.definition.string.perl'
       '1':
-        'name': 'string.unquoted.heredoc.perl'
+        'name': 'punctuation.definition.string.perl'
       '2':
+        'name': 'string.unquoted.heredoc.perl'
+      '3':
         'name': 'punctuation.definition.heredoc.perl'
+      '5':
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
     'contentName': 'string.unquoted.heredoc.perl'
-    'end': '(^\\3$)'
+    'end': '(^\\4$)'
     'patterns': [
       {
         'include': '#escaped_char'

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -465,7 +465,7 @@ Assigned to: @<<<<<<<<<<<<<<<<<<<<<< ^<<<<<<<<<<<<<<<<<<<<<<<<<<<<
       expect(lines[25][0]).toEqual value: "~                                    ^<<<<<<<<<<<<<<<<<<<<<<<...", scopes: ["source.perl", "meta.format.perl"]
       expect(lines[27][0]).toEqual value: ".", scopes: ["source.perl", "meta.format.perl"]
 
-  describe "when a function call tokenizes", ->
+  describe "when a heredoc tokenizes", ->
     it "does not highlight the whole line", ->
       lines = grammar.tokenizeLines("""$asd->foo(<<TEST, $bar, s/foo/bar/g);
       asd

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -464,3 +464,12 @@ Assigned to: @<<<<<<<<<<<<<<<<<<<<<< ^<<<<<<<<<<<<<<<<<<<<<<<<<<<<
       expect(lines[23][0]).toEqual value: "~                                    ^<<<<<<<<<<<<<<<<<<<<<<<<<<<<", scopes: ["source.perl", "meta.format.perl"]
       expect(lines[25][0]).toEqual value: "~                                    ^<<<<<<<<<<<<<<<<<<<<<<<...", scopes: ["source.perl", "meta.format.perl"]
       expect(lines[27][0]).toEqual value: ".", scopes: ["source.perl", "meta.format.perl"]
+
+  describe "when a function call tokenizes", ->
+    it "does not highlight the whole line", ->
+      lines = grammar.tokenizeLines("""$asd->foo(<<TEST, $bar, s/foo/bar/g);
+      asd
+      TEST""")
+      expect(lines[0][4]).toEqual value: "<<", scopes: ["source.perl", "punctuation.definition.string.perl", "string.unquoted.heredoc.perl", "punctuation.definition.heredoc.perl"]
+      expect(lines[0][5]).toEqual value: "TEST", scopes: ["source.perl", "punctuation.definition.string.perl", "string.unquoted.heredoc.perl"]
+      expect(lines[0][6]).toEqual value: ", ", scopes: ["source.perl"]

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -468,8 +468,21 @@ Assigned to: @<<<<<<<<<<<<<<<<<<<<<< ^<<<<<<<<<<<<<<<<<<<<<<<<<<<<
   describe "when a heredoc tokenizes", ->
     it "does not highlight the whole line", ->
       lines = grammar.tokenizeLines("""$asd->foo(<<TEST, $bar, s/foo/bar/g);
-      asd
-      TEST""")
+asd
+TEST
+;""")
       expect(lines[0][4]).toEqual value: "<<", scopes: ["source.perl", "punctuation.definition.string.perl", "string.unquoted.heredoc.perl", "punctuation.definition.heredoc.perl"]
       expect(lines[0][5]).toEqual value: "TEST", scopes: ["source.perl", "punctuation.definition.string.perl", "string.unquoted.heredoc.perl"]
       expect(lines[0][6]).toEqual value: ", ", scopes: ["source.perl"]
+      expect(lines[3][0]).toEqual value: ";", scopes: ["source.perl"]
+
+    it "does not highlight variables and escape sequences in a single quote heredoc", ->
+      lines = grammar.tokenizeLines("""$asd->foo(<<'TEST');
+$asd\\n
+;""")
+      expect(lines[1][0]).toEqual value: "$asd\\n", scopes: ["source.perl", "string.unquoted.heredoc.quote.perl"]
+
+      lines = grammar.tokenizeLines("""$asd->foo(<<\\TEST);
+$asd\\n
+;""")
+      expect(lines[1][0]).toEqual value: "$asd\\n", scopes: ["source.perl", "string.unquoted.heredoc.quote.perl"]


### PR DESCRIPTION
Now the heredoc only highlights the starting part in the firstline instead of the whole line.
This fixes #2, #26
![heredoc_examples](https://cloud.githubusercontent.com/assets/1900106/6730276/37fc4578-ce3b-11e4-967b-c4a7797c2fdd.png)

Added missing `<<JAVASCRIPT` highlighting.

@kevinsawicki is still need some answers, it would be nice if someone of your team could answer it:
* https://github.com/atom/language-perl/issues/1 last comment
* https://github.com/atom/language-perl/issues/18
* https://github.com/atom/language-perl/issues/27