### PR TITLE
Do not tread ( in a class as a group

### DIFF
--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -302,6 +302,20 @@
             'include': '#variable'
           }
           {
+            'begin': '\\['
+            'end': '\\]'
+            'patterns': [
+              {
+                'comment': 'This is to prevent thinks like qr/foo$/ to treat $/ as a variable'
+                'match': '\\$(?=[^\\s\\w\\\'\\{\\[\\(\\<])'
+                'name': 'keyword.control.anchor.perl'
+              }
+              {
+                'include': '#escaped_char'
+              }
+            ]
+          }
+          {
             'include': '#nested_parens_interpolated'
           }
         ]

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -61,7 +61,7 @@ describe "perl grammar", ->
       expect(tokens[4]).toEqual value: ")", scopes: ["source.perl", "string.regexp.compile.nested_parens.perl", "punctuation.definition.string.perl"]
       expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
 
-    it "does not tread ( in a class as a group", ->
+    it "does not treat ( in a class as a group", ->
       {tokens} = grammar.tokenizeLine("m/ \\A [(]? [?] .* - /smx")
       expect(tokens[1]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl", "punctuation.definition.string.perl"]
       expect(tokens[5]).toEqual value: "[", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl"]

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -61,6 +61,15 @@ describe "perl grammar", ->
       expect(tokens[4]).toEqual value: ")", scopes: ["source.perl", "string.regexp.compile.nested_parens.perl", "punctuation.definition.string.perl"]
       expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
 
+    it "does not tread ( in a class as a group", ->
+      {tokens} = grammar.tokenizeLine("m/ \\A [(]? [?] .* - /smx")
+      expect(tokens[1]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl", "punctuation.definition.string.perl"]
+      expect(tokens[5]).toEqual value: "[", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl"]
+      expect(tokens[6]).toEqual value: "(", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl"]
+      expect(tokens[7]).toEqual value: "]", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl"]
+      expect(tokens[13]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find-m.simple-delimiter.perl", "punctuation.definition.string.perl"]
+      expect(tokens[14]).toEqual value: "smx", scopes: ["source.perl", "string.regexp.find-m.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+
 
   describe "when a regexp find tokenizes", ->
     it "works with all bracket/seperator variations", ->


### PR DESCRIPTION
Fix which breakings highlighing if a class contains `(`:
![grouping_fixes](https://cloud.githubusercontent.com/assets/1900106/8268182/36d010b4-177c-11e5-9ed4-20423b4dba34.png)
