### PR TITLE
Stop highlight after __DATA__ and __END__

### DIFF
--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -725,7 +725,7 @@
     'name': 'constant.language.perl'
   }
   {
-    'begin': '(__DATA__)\\n?'
+    'begin': '\\b(__DATA__)\\n?'
     'captures':
       '1':
         'name': 'constant.language.perl'

--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -721,8 +721,15 @@
     'name': 'string.regexp.replace.perl'
   }
   {
-    'match': '\\b(__FILE__|__LINE__|__PACKAGE__|__SUB__|__DATA__|__END__)\\b'
+    'match': '\\b(__FILE__|__LINE__|__PACKAGE__|__SUB__|__END__)\\b'
     'name': 'constant.language.perl'
+  }
+  {
+    'begin': '(__DATA__)\\n?'
+    'captures':
+      '1':
+        'name': 'constant.language.perl'
+    'contentName': 'text.embedded.perl'
   }
   {
     'match': '(?<!->)\\b(continue|die|do|else|elsif|exit|for|foreach|goto|if|last|next|redo|return|select|unless|until|wait|while|switch|case|require|use|eval)\\b'

--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -721,11 +721,11 @@
     'name': 'string.regexp.replace.perl'
   }
   {
-    'match': '\\b(__FILE__|__LINE__|__PACKAGE__|__SUB__|__END__)\\b'
+    'match': '\\b(__FILE__|__LINE__|__PACKAGE__|__SUB__)\\b'
     'name': 'constant.language.perl'
   }
   {
-    'begin': '\\b(__DATA__)\\n?'
+    'begin': '\\b(__DATA__|__END__)\\n?'
     'captures':
       '1':
         'name': 'constant.language.perl'


### PR DESCRIPTION
The two control characters `^D` and `^Z`, and the tokens `__END__` and `__DATA__` may be used to indicate the logical end of the script before the actual end of file. Any following text is ignored.

http://perldoc.perl.org/perldata.html#Special-Literals