### PR TITLE
Allow standalone regex to hightlight as a regex

### DIFF
--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -637,7 +637,7 @@
     ]
   }
   {
-    'begin': '(?<=\\(|\\{|~|&)\\s*((\\/))'
+    'begin': '(?<=\\(|\\{|~|&|\\s)((\\/))'
     'beginCaptures':
       '1':
         'name': 'string.regexp.find.perl'

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -79,13 +79,12 @@ describe "perl grammar", ->
   describe "when a regexp find tokenizes", ->
     it "works with all bracket/seperator variations", ->
       {tokens} = grammar.tokenizeLine(" =~ /text/acdegilmoprsux;")
-      expect(tokens[0]).toEqual value: " =~", scopes: ["source.perl"]
-      expect(tokens[1]).toEqual value: " ", scopes: ["source.perl"]
-      expect(tokens[2]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
-      expect(tokens[3]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find.perl"]
-      expect(tokens[4]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
-      expect(tokens[5]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
-      expect(tokens[6]).toEqual value: ";", scopes: ["source.perl"]
+      expect(tokens[0]).toEqual value: " =~ ", scopes: ["source.perl"]
+      expect(tokens[1]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
+      expect(tokens[2]).toEqual value: "text", scopes: ["source.perl", "string.regexp.find.perl"]
+      expect(tokens[3]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
+      expect(tokens[4]).toEqual value: "acdegilmoprsux", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[5]).toEqual value: ";", scopes: ["source.perl"]
 
       {tokens} = grammar.tokenizeLine(" =~ m/text/acdegilmoprsux;")
       expect(tokens[0]).toEqual value: " =~ ", scopes: ["source.perl"]
@@ -136,9 +135,8 @@ describe "perl grammar", ->
       lines = grammar.tokenizeLines("""$asd =~ /
       (\\d)
       /x""")
-      expect(lines[0][2]).toEqual value: " =~", scopes: ["source.perl"]
-      expect(lines[0][3]).toEqual value: " ", scopes: ["source.perl"]
-      expect(lines[0][4]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
+      expect(lines[0][2]).toEqual value: " =~ ", scopes: ["source.perl"]
+      expect(lines[0][3]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
       expect(lines[1][0]).toEqual value: "(", scopes: ["source.perl", "string.regexp.find.perl"]
       expect(lines[1][2]).toEqual value: ")", scopes: ["source.perl", "string.regexp.find.perl"]
       expect(lines[2][0]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
@@ -158,12 +156,11 @@ describe "perl grammar", ->
       expect(tokens[6]).toEqual value: ") {}", scopes: ["source.perl"]
 
       {tokens} = grammar.tokenizeLine("if ($_ && / hello /i) {}")
-      expect(tokens[5]).toEqual value: " ", scopes: ["source.perl"]
-      expect(tokens[6]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
-      expect(tokens[7]).toEqual value: " hello ", scopes: ["source.perl", "string.regexp.find.perl"]
-      expect(tokens[8]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
-      expect(tokens[9]).toEqual value: "i", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
-      expect(tokens[10]).toEqual value: ") {}", scopes: ["source.perl"]
+      expect(tokens[5]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
+      expect(tokens[6]).toEqual value: " hello ", scopes: ["source.perl", "string.regexp.find.perl"]
+      expect(tokens[7]).toEqual value: "/", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl"]
+      expect(tokens[8]).toEqual value: "i", scopes: ["source.perl", "string.regexp.find.perl", "punctuation.definition.string.perl", "keyword.control.regexp-option.perl"]
+      expect(tokens[9]).toEqual value: ") {}", scopes: ["source.perl"]
 
   describe "when a regexp replace tokenizes", ->
     it "works with all bracket/seperator variations", ->


### PR DESCRIPTION
Currently a standalone regex like `/this is my regex/i` gets ignored, this PR should fix this.

DONT MERGE, ill add some specs for it and than ill add the "needs-review" label.

Fixes #53 