### PR TITLE
Add an "impossible" rule to Perl's __END__ pattern

### DIFF
--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -745,6 +745,7 @@
       '1':
         'name': 'constant.language.perl'
     'contentName': 'text.embedded.perl'
+    'end': '(?=N)A'
   }
   {
     'match': '(?<!->)\\b(continue|die|do|else|elsif|exit|for|foreach|goto|if|last|next|redo|return|select|unless|until|wait|while|switch|case|require|use|eval)\\b'

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -309,6 +309,15 @@ describe "perl grammar", ->
       {tokens} = grammar.tokenizeLine("__TEST__")
       expect(tokens[0]).toEqual value: "__TEST__", scopes: ["source.perl", "string.unquoted.program-block.perl", "punctuation.definition.string.begin.perl"]
 
+  describe "when an __END__ constant is used", ->
+    it "does not highlight subsequent lines", ->
+      lines = grammar.tokenizeLines("""
+      "String";
+      __END__
+      "String";
+      """)
+      expect(lines[2][0]).toEqual value: '"String";', scopes: ["source.perl", "text.embedded.perl"]
+
   describe "tokenizes compile phase keywords", ->
     it "does highlight all compile phase keywords", ->
       {tokens} = grammar.tokenizeLine("BEGIN")


### PR DESCRIPTION
While Atom permits the omission of a range pattern's "end" rule, not all engines using TextMate's rendering engine do, including TextMate itself. For example, this rule is ignored by the [Lightshow app](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=source.perl&grammar_url=&grammar_text=&code_source=from-text&code_url=&code=%22String%22%3B%0D%0A__END__%0D%0A%22String%22%3B) when previewing a piece of Perl code containing freeform text following an \_\_END\_\_ line.

Admittedly, this is a pretty minor issue, since I only just noticed GitHub's syntax highlighting is unaffected by this (Lightshow's probably using an older version of First-Mate, or whatever's powering the rendering). But I only noticed this *after* I'd made the almost-completely-useless fix, so... eh... :')