### PR TITLE
Fix regex highlighting when using m/xxx/m syntax

### DIFF
--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -169,6 +169,15 @@
       }
     ]
   }
+{
+    'name' : 'punctuation.regex.test';
+    'comment' : 'poor mans solution to m/xxx/m issue with syntax';
+    'begin' : 'm\/';
+    'end' : '\/m?';
+    'captures' :
+        '0' :
+            'name' : 'punctuation.definition.string.perl'
+}
   {
     'applyEndPatternLast': 1
     'begin': '(?<!\\{|\\+|\\-)\\b(?=m\\s*[^\\sa-zA-Z0-9])'


### PR DESCRIPTION
This pull request has a fix for the issue described in issue #61 

This is a very simply implemented workaround, but doesn't seem to cause any other issues.