### PR TITLE
Improve highlighting of Pod commands

### DIFF
--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -744,7 +744,7 @@
     'captures':
       '1':
         'name': 'constant.language.perl'
-    'contentName': 'text.embedded.perl'
+    'contentName': 'comment.block.documentation.perl'
     'end': '(?=N)A'
   }
   {

--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -15,12 +15,21 @@
     'include': '#line_comment'
   }
   {
-    'begin': '^='
-    'captures':
-      '0':
-        'name': 'punctuation.definition.comment.perl'
-    'end': '^=cut'
+    'begin': '^(?==)'
+    'end': '^(=cut\\b.*$)'
+    'endCaptures':
+      '1':
+        'patterns': [
+          {
+            'include': '#pod'
+          }
+        ]
     'name': 'comment.block.documentation.perl'
+    'patterns': [
+      {
+        'include': '#pod'
+      }
+    ]
   }
   {
     'include': '#variable'
@@ -746,6 +755,11 @@
         'name': 'constant.language.perl'
     'contentName': 'comment.block.documentation.perl'
     'end': '(?=N)A'
+    'patterns': [
+      {
+        'include': '#pod'
+      }
+    ]
   }
   {
     'match': '(?<!->)\\b(continue|default|die|do|else|elsif|exit|for|foreach|given|goto|if|last|next|redo|return|select|unless|until|wait|when|while|switch|case|require|use|eval)\\b'
@@ -1921,6 +1935,98 @@
       }
       {
         'include': '#nested_parens_interpolated'
+      }
+    ]
+  'pod':
+    'patterns': [
+      {
+        # Niladic POD commandss
+        'match': '^=(pod|back|cut)\\b'
+        'name': 'storage.type.class.pod.perl'
+      }
+      {
+        # Embedded text/data
+        'begin': '^(=begin)\\s+(html)\\s*$'
+        'end': '^(=end)\\s+(html)|^(?==cut)'
+        'name': 'meta.embedded.pod.perl'
+        'beginCaptures':
+          '1':
+            'name': 'storage.type.class.pod.perl'
+          '2':
+            'name': 'variable.other.pod.perl'
+        'endCaptures':
+          '1':
+            'name': 'storage.type.class.pod.perl'
+          '2':
+            'name': 'variable.other.pod.perl'
+        'contentName': 'text.embedded.html.basic'
+        'patterns': [
+          {
+            'include': 'text.html.basic'
+          }
+        ]
+      }
+      {
+        # POD commands with highlighted arguments
+        'match': '^(=(?:head[1-4]|item|over|encoding|begin|end|for))\\b\\s*(.*)'
+        'captures':
+          '1':
+            'name': 'storage.type.class.pod.perl'
+          '2':
+            'name': 'variable.other.pod.perl'
+            'patterns': [
+              {
+                'include': '#pod-formatting'
+              }
+            ]
+      }
+      {
+        'include': '#pod-formatting'
+      }
+    ]
+  'pod-formatting':
+    'patterns': [
+      {
+        # Italic text
+        'match': 'I(?:<([^<>]+)>|<+(\\s+(?:(?<!\\s)>|[^>])+\\s+)>+)'
+        'name': 'entity.name.type.instance.pod.perl'
+        'captures':
+          '1':
+            'name': 'markup.italic.pod.perl'
+          '2':
+            'name': 'markup.italic.pod.perl'
+      }
+      {
+        # Bold text
+        'match': 'B(?:<([^<>]+)>|<+(\\s+(?:(?<!\\s)>|[^>])+\\s+)>+)'
+        'name': 'entity.name.type.instance.pod.perl'
+        'captures':
+          '1':
+            'name': 'markup.bold.pod.perl'
+          '2':
+            'name': 'markup.bold.pod.perl'
+      }
+      {
+        # Constant-width/"preformatted" text
+        'match': 'C(?:<([^<>]+)>|<+(\\s+(?:(?<!\\s)>|[^>])+\\s+)>+)'
+        'name': 'entity.name.type.instance.pod.perl'
+        'captures':
+          '1':
+            'name': 'markup.raw.pod.perl'
+          '2':
+            'name': 'markup.raw.pod.perl'
+      }
+      {
+        # Link
+        'match': 'L<([^>]+)>'
+        'name': 'entity.name.type.instance.pod.perl'
+        'captures':
+          '1':
+            'name': 'markup.underline.link.hyperlink.pod.perl'
+      }
+      {
+        'match': '[EFSXZ]<[^>]*>'
+        'name': 'entity.name.type.instance.pod.perl'
       }
     ]
   'variable':

--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -1940,7 +1940,7 @@
   'pod':
     'patterns': [
       {
-        # Niladic POD commandss
+        # Niladic Pod commandss
         'match': '^=(pod|back|cut)\\b'
         'name': 'storage.type.class.pod.perl'
       }
@@ -1967,7 +1967,7 @@
         ]
       }
       {
-        # POD commands with highlighted arguments
+        # Pod commands with highlighted arguments
         'match': '^(=(?:head[1-4]|item|over|encoding|begin|end|for))\\b\\s*(.*)'
         'captures':
           '1':

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe "perl grammar", ->
+describe "Perl grammar", ->
   grammar = null
 
   beforeEach ->
@@ -610,8 +610,8 @@ $asd\\n
       expect(tokens[4]).toEqual value: "#", scopes: ["source.perl", "comment.line.number-sign.perl", "punctuation.definition.comment.perl"]
       expect(tokens[5]).toEqual value: "this is my new class", scopes: ["source.perl", "comment.line.number-sign.perl"]
 
-  describe "when tokenising POD markup", ->
-    it "highlights POD commands", ->
+  describe "when tokenising Pod markup", ->
+    it "highlights Pod commands", ->
       lines = grammar.tokenizeLines """
         =pod
         Bar

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -310,13 +310,13 @@ describe "perl grammar", ->
       expect(tokens[0]).toEqual value: "__TEST__", scopes: ["source.perl", "string.unquoted.program-block.perl", "punctuation.definition.string.begin.perl"]
 
   describe "when an __END__ constant is used", ->
-    it "does not highlight subsequent lines", ->
+    it "highlights subsequent lines as comments", ->
       lines = grammar.tokenizeLines("""
       "String";
       __END__
       "String";
       """)
-      expect(lines[2][0]).toEqual value: '"String";', scopes: ["source.perl", "text.embedded.perl"]
+      expect(lines[2][0]).toEqual value: '"String";', scopes: ["source.perl", "comment.block.documentation.perl"]
 
   describe "tokenizes compile phase keywords", ->
     it "does highlight all compile phase keywords", ->


### PR DESCRIPTION
This PR introduces two improvements:

1. It adds comment-highlighting to every line following an `__END__` statement; such things are typically used for embedding Pod markup, [especially in modules](https://github.com/libwww-perl/libwww-perl/blob/master/lib/LWP.pm#L11).

2. Pod commands are now highlighted in the same manner as JavaScript JSDoc tags are. I've used the same scope-names the JS grammar uses in the hopes of achieving some consistency in theme highlighting.