### PR TITLE
Fix '#' as a regex delimiter

### DIFF
--- a/grammars/perl.cson
+++ b/grammars/perl.cson
@@ -350,9 +350,9 @@
   }
   {
     'applyEndPatternLast': 1
-    'begin': '\\b(?=(?<!\\&)(s)(\\s+\\S|\\s*[;\\,\\#\\{\\}\\(\\)\\[<]|$))'
+    'begin': '\\b(?=(?<!\\&)(s)(\\s+\\S|\\s*[;\\,\\{\\}\\(\\)\\[<]|$))'
     'comment': 'string.regexp.replace.perl'
-    'end': '((([egimosxradlupcn]*)))(?=(\\s+\\S|\\s*[;\\,\\#\\}\\)\\]>]|$))'
+    'end': '((([egimosxradlupcn]*)))(?=(\\s+\\S|\\s*[;\\,\\}\\)\\]>]|$))'
     'endCaptures':
       '1':
         'name': 'string.regexp.replace.perl'

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -76,6 +76,13 @@ describe "Perl grammar", ->
       expect(tokens[4]).toEqual value: "m", scopes: ["source.perl", "constant.other.bareword.perl"]
       expect(tokens[5]).toEqual value: "}", scopes: ["source.perl"]
 
+    it "does not treat '#' as a comment in regex match", ->
+      {tokens} = grammar.tokenizeLine("$asd =~ s#asd#foo#;")
+      expect(tokens[3]).toEqual value: "s", scopes: ["source.perl", "string.regexp.replaceXXX.simple_delimiter.perl", "punctuation.definition.string.perl", "support.function.perl"]
+      expect(tokens[4]).toEqual value: "#", scopes: ["source.perl", "string.regexp.replaceXXX.simple_delimiter.perl", "punctuation.definition.string.perl"]
+      expect(tokens[6]).toEqual value: "#", scopes: ["source.perl", "string.regexp.replaceXXX.format.simple_delimiter.perl", "punctuation.definition.string.perl"]
+      expect(tokens[8]).toEqual value: "#", scopes: ["source.perl", "string.regexp.replaceXXX.format.simple_delimiter.perl", "punctuation.definition.string.perl"]
+
   describe "when a regexp find tokenizes", ->
     it "works with all bracket/seperator variations", ->
       {tokens} = grammar.tokenizeLine(" =~ /text/acdegilmnoprsux;")


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/1900106/18669469/80b2f7aa-7f3b-11e6-9d47-fdff2a8d0a7b.png)

Now:
![image](https://cloud.githubusercontent.com/assets/1900106/18669455/6e532c06-7f3b-11e6-8791-1aac8996ff40.png)

/cc @atom/feedback 